### PR TITLE
[fix] : Github Action 환경변수 문제 해결

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,10 @@ jobs:
       ### Docker 이미지 빌드 & 푸시
       - name: Build and push Docker image
         run: |
-          docker build -t $DOCKER_IMAGE .
+          echo "API URL : ${{ vars.NEXT_PUBLIC_API_URL }}"
+          docker build \
+            --build-arg NEXT_PUBLIC_API_URL="${{ vars.NEXT_PUBLIC_API_URL }}" \
+            -t $DOCKER_IMAGE .
           docker push $DOCKER_IMAGE
 
       ### EC2에 SSH 접속하여 Docker pull 및 재시작

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,11 @@ COPY package.json yarn.lock ./
 RUN yarn install
 
 COPY . .
+
+# 빌드 시 환경 변수 전달
+ARG NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+
 RUN yarn build
 
 # 2단계: 런타임 스테이지


### PR DESCRIPTION
### 문제원인
- 현재 프로젝트에서 env 로 API 주소를 관리
- GithubAction 에서는 해당 env 를 가져올 수 없기 때문에 서버에 접속되지 않는 문제 발생

### 문제해결
- Docker image 빌드시점에 필요한 env 변수들을 가져올 수 있게 수정
- Github Action 콘솔에 해당 환경변수 등록