### PR TITLE
FIX: 최종 발표전 회고페이지 수정사항 반영

### DIFF
--- a/src/composite/mypage/editProfile/component.tsx
+++ b/src/composite/mypage/editProfile/component.tsx
@@ -44,7 +44,13 @@ export const EditProfile = () => {
           <div className="flex flex-col gap-2">
             <h2 className="heading-2-bold">{profile.userName}</h2>
             <FlexBox className="gap-2">
-              <Badge type="default" size="md" label={profile.jobRole} />
+              <Badge
+                type="default"
+                size="md"
+                label={profile.jobRole}
+                color="bg-[rgba(125,94,247,0.22)]"
+                textColor="text-accent-violet"
+              />
               <span className="body-1-normal text-label-neutral">{profile.careerMapDisplay[profile.careerYear]}</span>
             </FlexBox>
           </div>

--- a/src/composite/retrospect/detail/api.ts
+++ b/src/composite/retrospect/detail/api.ts
@@ -31,7 +31,6 @@ export const getGoalRetrosepctById = async (id: string) => {
     const data = response.data;
     return data;
   } catch (error) {
-    console.error(error);
     throw error;
   }
 };
@@ -42,7 +41,6 @@ export const getCompletedGoals = async () => {
     const data = response.data;
     return data;
   } catch (error) {
-    console.error(error);
     throw error;
   }
 };
@@ -53,7 +51,6 @@ export const getGoalById = async (goalId: string) => {
     const data = response.data;
     return data;
   } catch (error) {
-    console.error(error);
     throw error;
   }
 };
@@ -63,7 +60,6 @@ export const getWeeklyTodos = async (goalId: string, planId: string) => {
     const response = await apiClient.get<WeeklyTodosResponse>(`/todos?goalId=${goalId}&planId=${planId}`);
     return response.data;
   } catch (error) {
-    console.error(error);
     throw error;
   }
 };

--- a/src/composite/retrospect/detail/components/LastWeeklyPlans.tsx
+++ b/src/composite/retrospect/detail/components/LastWeeklyPlans.tsx
@@ -10,26 +10,16 @@ import { getGoalById, getWeeklyTodos, WeeklyTodosData } from '../api';
 import { Goal, Plan } from '@/shared/type/goal';
 import { useWeeklyTodos } from '../hooks/useWeeklyTodos';
 
-const weekDays = ['월', '화', '수', '목', '금', '토', '일'] as const;
 export const LastWeeklyPlans = () => {
   const router = useRouter();
   const goalId = useParams<{ id: string }>().id;
   const [goal, setGoal] = useState<Goal | null>(null);
+  const [plans, setPlans] = useState<Plan[]>([]);
   const [totalWeeklyTodos, setTotalWeeklyTodos] = useState<WeeklyTodosData[]>([]); // 모든 주차의 todos를 담는 상태
-  const [currentWeek, setCurrentWeek] = useState(1);
-
-  // 현재 주차의 todos 데이터 (빈 객체로 초기화)
-  const currentWeekTodos = totalWeeklyTodos[currentWeek - 1] || {
-    MONDAY: [],
-    TUESDAY: [],
-    WEDNESDAY: [],
-    THURSDAY: [],
-    FRIDAY: [],
-    SATURDAY: [],
-    SUNDAY: [],
-  };
-
-  const { weeklyStates, selectedDay, setSelectedDay, selectedDayTodos } = useWeeklyTodos(currentWeekTodos);
+  const { weeklyStates, selectedDay, setSelectedDay, selectedDayTodos, handleWeekChange, currentWeek } = useWeeklyTodos(
+    totalWeeklyTodos,
+    plans
+  );
 
   const getAllWeeklyTodos = async (goalId: string, plansData: Plan[]) => {
     // 모든 주차 데이터를 병렬로 가져오기
@@ -53,23 +43,13 @@ export const LastWeeklyPlans = () => {
       const goalData = res.data;
       const plansData = goalData.plans;
       setGoal(goalData);
+      setPlans(plansData);
 
       const weeklyTodos = await getAllWeeklyTodos(goalId, plansData);
       setTotalWeeklyTodos(weeklyTodos);
     };
     initData();
   }, []);
-
-  // 주차 변경 핸들러
-  const handleWeekChange = (direction: number) => {
-    const newWeek = currentWeek + direction;
-    const maxWeeks = totalWeeklyTodos.length;
-
-    if (newWeek >= 1 && newWeek <= maxWeeks) {
-      setCurrentWeek(newWeek);
-      setSelectedDay(null); // 주차 변경 시 선택된 요일 초기화
-    }
-  };
 
   return (
     <>
@@ -159,7 +139,11 @@ export const LastWeeklyPlans = () => {
                 isSelected={selectedDay === state.korDay}
                 onClick={() => setSelectedDay(state.korDay)}
               />
-              {/* <span className="font-semibold">{state.date}</span> */}
+              <span
+                className={`caption-1-bold ${selectedDay === state.korDay ? 'text-white' : 'text-label-alternative'}`}
+              >
+                {state.dateString}
+              </span>
             </FlexBox>
           ))}
         </FlexBox>

--- a/src/composite/retrospect/hooks.ts
+++ b/src/composite/retrospect/hooks.ts
@@ -2,15 +2,12 @@ import { useEffect, useState } from 'react';
 import { Plan, Retrospect } from './type';
 import { getWeeklyRetrospectByGoalId } from './inProgress/api';
 import { putWeeklyRetrospect } from '@/feature/retrospects/weeklyRetrospect/api';
-import { useToast } from '@/shared/components/feedBack/toast';
-import { AxiosError } from 'axios';
 
-export const useWeeklyRetrospect = (id: string) => {
+export const useWeeklyRetrospect = (id: string | null) => {
   const [weeklyRetrospect, setWeeklyRetrospect] = useState<Retrospect[]>([]);
   const [plans, setPlans] = useState<Plan[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isError, setIsError] = useState(false);
-  const { showToast } = useToast();
 
   useEffect(() => {
     if (!id) return;
@@ -29,7 +26,6 @@ export const useWeeklyRetrospect = (id: string) => {
     } catch (error) {
       setIsError(true);
       console.error(error);
-      throw Error;
     }
     setIsLoading(false);
   };
@@ -43,15 +39,8 @@ export const useWeeklyRetrospect = (id: string) => {
     try {
       await putWeeklyRetrospect(weeklyRetrospectId, newRetrospect);
       if (weeklyRetrospectId) fetchWeeklyRetrosepct();
-    } catch (err) {
-      const error = err as AxiosError<{ message: string }>;
+    } catch (error) {
       console.error(error);
-
-      if (error.response?.data?.message) {
-        throw new Error(error.response.data.message);
-      }
-
-      throw new Error('알 수 없는 오류가 발생했습니다.');
     }
   };
 

--- a/src/composite/retrospect/inProgress/api.ts
+++ b/src/composite/retrospect/inProgress/api.ts
@@ -2,21 +2,6 @@ import { apiClient } from '@/shared/lib/apiClient';
 import { Retrospect, Plan } from '../type';
 import { Goal } from '@/shared/type/goal';
 
-/**
- * @deprecated - Goal 타입으로 대체
- */
-// interface InprogressRetrospectResponse {
-//   data: {
-//     id: string;
-//     userName: string;
-//     name: string;
-//     duration: Duration;
-//     toBe: string;
-//     categoray: string;
-//     plans: Plan[];
-//   }[];
-// }
-
 interface InProgressRetrospectResponse {
   data: Goal[];
 }

--- a/src/composite/retrospect/inProgress/api.ts
+++ b/src/composite/retrospect/inProgress/api.ts
@@ -1,8 +1,10 @@
-import { InProgress } from './component';
 import { apiClient } from '@/shared/lib/apiClient';
-import { Duration, Retrospect, Plan } from '../type';
+import { Retrospect, Plan } from '../type';
 import { Goal } from '@/shared/type/goal';
 
+/**
+ * @deprecated - Goal 타입으로 대체
+ */
 // interface InprogressRetrospectResponse {
 //   data: {
 //     id: string;

--- a/src/composite/retrospect/inProgress/component.tsx
+++ b/src/composite/retrospect/inProgress/component.tsx
@@ -10,25 +10,6 @@ import { RetrospectLocked } from './components/RetrospectLocked';
 
 export const InProgress = () => {
   const { currentGoal } = useGoalSelector();
-  /** 
-  /* @deprecated - 진행중인 목표 중복 조회 대신에 context기반 useGoalSelector훅을 통해 현재 진행형 목표 조회로 교체
-   */
-  // const [ingGoal, setIngGoal] = useState<Goal | null>(null);
-  // const [goalId, setGoalId] = useState<string>('');
-
-  // // 1. Goal과 Duration 가져오기
-  // useEffect(() => {
-  //   const fetchGoal = async () => {
-  //     const res = await getProgressRetrospect();
-  //     const currentGoal = res.data[0];
-  //     if (currentGoal) {
-  //       setIngGoal(currentGoal);
-  //       setGoalId(currentGoal.id);
-  //     }
-  //   };
-  //   fetchGoal();
-  // }, []);
-
   // goalId를 useWeeklyRetrospect에 전달
   const { weeklyRetrospect, plans, updateWeeklyRetrospect } = useWeeklyRetrospect(
     currentGoal !== null ? currentGoal.id : null

--- a/src/composite/retrospect/inProgress/component.tsx
+++ b/src/composite/retrospect/inProgress/component.tsx
@@ -1,49 +1,50 @@
 'use client';
 
-import { RoadMap } from '@/shared/components/display/RoadMap';
 import { WeeklyRetrospect } from '@/feature/retrospects/weeklyRetrospect/component';
-import { EntireRetrospect } from '@/feature/retrospects/entireRetrospect/component';
 import FlexBox from '@/shared/components/foundation/FlexBox';
 import { useWeeklyRetrospect } from '../hooks';
-import { useEffect, useState } from 'react';
-import { getProgressRetrospect } from './api';
 import { CreateGoalButton } from '@/feature/goal';
 import { WeeklyGoalBanner } from '@/feature/goal/weeklyGoalBanner';
-import { Goal } from '@/shared/type/goal';
+import { useGoalSelector } from '@/model/goal/context';
+import { RetrospectLocked } from './components/RetrospectLocked';
 
 export const InProgress = () => {
-  const [ingGoal, setIngGoal] = useState<Goal | null>(null);
-  const [goalId, setGoalId] = useState<string>('');
+  const { currentGoal } = useGoalSelector();
+  /** 
+  /* @deprecated - 진행중인 목표 중복 조회 대신에 context기반 useGoalSelector훅을 통해 현재 진행형 목표 조회로 교체
+   */
+  // const [ingGoal, setIngGoal] = useState<Goal | null>(null);
+  // const [goalId, setGoalId] = useState<string>('');
 
-  // 1. Goal과 Duration 가져오기
-  useEffect(() => {
-    const fetchGoal = async () => {
-      const res = await getProgressRetrospect();
-      const currentGoal = res.data[0];
-      if (currentGoal) {
-        setIngGoal(currentGoal);
-        setGoalId(currentGoal.id);
-      }
-    };
-    fetchGoal();
-  }, []);
+  // // 1. Goal과 Duration 가져오기
+  // useEffect(() => {
+  //   const fetchGoal = async () => {
+  //     const res = await getProgressRetrospect();
+  //     const currentGoal = res.data[0];
+  //     if (currentGoal) {
+  //       setIngGoal(currentGoal);
+  //       setGoalId(currentGoal.id);
+  //     }
+  //   };
+  //   fetchGoal();
+  // }, []);
 
-  // 2. goalId를 useWeeklyRetrospect에 전달
-  const { weeklyRetrospect, plans, updateWeeklyRetrospect } = useWeeklyRetrospect(goalId);
+  // goalId를 useWeeklyRetrospect에 전달
+  const { weeklyRetrospect, plans, updateWeeklyRetrospect } = useWeeklyRetrospect(
+    currentGoal !== null ? currentGoal.id : null
+  );
 
   return (
     <>
-      {ingGoal ? (
+      {currentGoal ? (
         <>
-          <WeeklyGoalBanner goal={ingGoal} />
-          <EntireRetrospect goalId={goalId} />
-          {weeklyRetrospect && (
-            <WeeklyRetrospect
-              weeklyRetrospect={weeklyRetrospect}
-              plans={plans}
-              updateWeeklyRetrospect={updateWeeklyRetrospect}
-            />
-          )}
+          <WeeklyGoalBanner goal={currentGoal} />
+          <RetrospectLocked />
+          <WeeklyRetrospect
+            weeklyRetrospect={weeklyRetrospect}
+            plans={plans}
+            updateWeeklyRetrospect={updateWeeklyRetrospect}
+          />
         </>
       ) : (
         <FlexBox direction="col" className="justify-center space-y-4">

--- a/src/composite/retrospect/inProgress/components/RetrospectLocked.tsx
+++ b/src/composite/retrospect/inProgress/components/RetrospectLocked.tsx
@@ -1,26 +1,57 @@
+import { Accordion } from '@/shared/components/layout/Accordion';
 import FlexBox from '@/shared/components/foundation/FlexBox';
+import Image from 'next/image';
 
-interface RetrospectLockedProps {
-  title: string;
-  label?: string;
-}
-export const RetrospectLocked = ({ title, label = '' }: RetrospectLockedProps) => {
+export const RetrospectLocked = () => {
   return (
-    <div className="flex flex-col gap-4 w-full bg-elevated-normal py-5 px-6 pb-8 rounded-lg">
-      <p className="headline-1-bold text-label-normal">{title}</p>
-      <label className="text-primary-normal">{label}</label>
-      <FlexBox className="bg-inverse-primary/5 py-3 px-4 w-full rounded-lg gap-4">
-        <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
-          <path
-            d="M6.41667 10.084V6.41732C6.41667 5.20174 6.89955 4.03595 7.75909 3.17641C8.61864 2.31687 9.78442 1.83398 11 1.83398C12.2156 1.83398 13.3814 2.31687 14.2409 3.17641C15.1004 4.03595 15.5833 5.20174 15.5833 6.41732V10.084M4.58333 10.084H17.4167C18.4292 10.084 19.25 10.9048 19.25 11.9173V18.334C19.25 19.3465 18.4292 20.1673 17.4167 20.1673H4.58333C3.57081 20.1673 2.75 19.3465 2.75 18.334V11.9173C2.75 10.9048 3.57081 10.084 4.58333 10.084Z"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            className="stroke-label-normal opacity-70"
-          />
-        </svg>
-        <p className="label-1-normal text-label-normal opacity-70">목표 완료시 업데이트 됩니다</p>
+    <Accordion
+      renderTitle={() => (
+        <FlexBox className="flex gap-4">
+          <p className="heading-2-bold text-label-normal">전체회고</p>
+          <div className="py-1 px-3 bg-purple-500/20 rounded-xl">
+            <label className="label-1-normal bg-gradient-to-r from-blue-500 to-accent-pink bg-clip-text text-transparent">
+              AI
+            </label>
+          </div>
+        </FlexBox>
+      )}
+    >
+      <FlexBox direction="col" className="gap-4">
+        <div className="flex gap-2 items-start pt-6 w-full">
+          <Image src="/character.png" alt="growit-character" width={100} height={100} />
+          <div className="flex flex-col gap-4 w-full bg-elevated-assistive py-5 px-6 pb-8 rounded-lg">
+            <p className="headline-1-bold text-label-normal">AI 인사이트</p>
+            <label className="text-primary-normal">회고 작성 전에, 이번 목표에 대한 AI 요약 및 조언을 받아봐!</label>
+            <FlexBox className="bg-inverse-primary/5 py-3 px-4 w-full rounded-lg gap-4">
+              <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+                <path
+                  d="M6.41667 10.084V6.41732C6.41667 5.20174 6.89955 4.03595 7.75909 3.17641C8.61864 2.31687 9.78442 1.83398 11 1.83398C12.2156 1.83398 13.3814 2.31687 14.2409 3.17641C15.1004 4.03595 15.5833 5.20174 15.5833 6.41732V10.084M4.58333 10.084H17.4167C18.4292 10.084 19.25 10.9048 19.25 11.9173V18.334C19.25 19.3465 18.4292 20.1673 17.4167 20.1673H4.58333C3.57081 20.1673 2.75 19.3465 2.75 18.334V11.9173C2.75 10.9048 3.57081 10.084 4.58333 10.084Z"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  className="stroke-label-normal opacity-70"
+                />
+              </svg>
+              <p className="label-1-normal text-label-normal opacity-70">목표 완료시 업데이트 됩니다</p>
+            </FlexBox>
+          </div>
+        </div>
+        <div className="flex flex-col gap-4 w-full bg-elevated-assistive py-5 px-6 pb-8 rounded-lg">
+          <p className="headline-1-bold text-label-normal">나의 회고</p>
+          <FlexBox className="bg-inverse-primary/5 py-3 px-4 w-full rounded-lg gap-4">
+            <svg width="22" height="22" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path
+                d="M6.41667 10.084V6.41732C6.41667 5.20174 6.89955 4.03595 7.75909 3.17641C8.61864 2.31687 9.78442 1.83398 11 1.83398C12.2156 1.83398 13.3814 2.31687 14.2409 3.17641C15.1004 4.03595 15.5833 5.20174 15.5833 6.41732V10.084M4.58333 10.084H17.4167C18.4292 10.084 19.25 10.9048 19.25 11.9173V18.334C19.25 19.3465 18.4292 20.1673 17.4167 20.1673H4.58333C3.57081 20.1673 2.75 19.3465 2.75 18.334V11.9173C2.75 10.9048 3.57081 10.084 4.58333 10.084Z"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="stroke-label-normal opacity-70"
+              />
+            </svg>
+            <p className="label-1-normal text-label-normal opacity-70">목표 완료시 업데이트 됩니다</p>
+          </FlexBox>
+        </div>
       </FlexBox>
-    </div>
+    </Accordion>
   );
 };

--- a/src/feature/retrospects/entireRetrospect/component.tsx
+++ b/src/feature/retrospects/entireRetrospect/component.tsx
@@ -3,8 +3,8 @@ import FlexBox from '@/shared/components/foundation/FlexBox';
 import { Accordion } from '@/shared/components/layout/Accordion';
 import { AISummaryBox } from './components/AISummaryBox';
 import { AISummaryButton } from './components/AISummaryButton';
-import Badge from '@/shared/components/display/Badge';
 import { useRetrospectAI } from './hook';
+import Badge from '@/shared/components/display/Badge';
 
 interface EntireRetrospectProps {
   goalId?: string;

--- a/src/shared/components/display/Badge.tsx
+++ b/src/shared/components/display/Badge.tsx
@@ -31,7 +31,7 @@ const Badge = ({
         : size === 'md'
           ? 'py-1 px-4 text-sm rounded-2xl'
           : size === 'lg'
-            ? 'py-2 px-5 text-sm rounded-2xl'
+            ? 'py-2 px-5 rounded-2xl'
             : className
   );
 

--- a/src/shared/type/goal.ts
+++ b/src/shared/type/goal.ts
@@ -16,4 +16,8 @@ export interface Plan {
   id: string;
   content: string;
   weekOfMonth: number;
+  duration?: {
+    startDate: string;
+    endDate: string;
+  };
 }


### PR DESCRIPTION
1. 상윤님께서 만들어주신 useGoalSelector로 기존 진행중 목표 조회 로직을 대체했습니다.
2. 백엔드에서 주차별 todo api의 응답데이터를 수정한 버전으로 반영되면 해당 API기반으로 "지난 주간 플랜" 페이지에 대해 완성할 예정입니다