### PR TITLE
[Feat]: 랜딩페이지/얼리버드 혜택 관련 컨텐츠 추가

### DIFF
--- a/src/composite/landing/footer/components/FooterLinks.tsx
+++ b/src/composite/landing/footer/components/FooterLinks.tsx
@@ -1,3 +1,4 @@
+import { urls } from '@/shared/constants/urls';
 import React from 'react';
 
 // 링크 데이터 타입 정의
@@ -13,8 +14,8 @@ interface LinkSection {
 
 const FooterLinks = () => {
   const supportLinks: LinkItem[] = [
-    { label: '개인정보처리방침', href: '#' },
-    { label: '이용약관', href: '#' },
+    { label: '개인정보처리방침', href: urls.customerInfo },
+    { label: '이용약관', href: urls.termsOfService },
   ];
   const linkSections: LinkSection[] = [{ title: '지원', links: supportLinks }];
 

--- a/src/composite/landing/hero/HeroSection.tsx
+++ b/src/composite/landing/hero/HeroSection.tsx
@@ -33,23 +33,51 @@ const HeroSection = () => {
         <div className="absolute inset-0 bg-[linear-gradient(rgba(53,217,66,0.03)_1px,transparent_1px),linear-gradient(90deg,rgba(53,217,66,0.03)_1px,transparent_1px)] bg-[size:20px_20px]" />
       </div>
 
-      <div className="relative z-10 max-w-7xl mx-auto w-full">
-        <div className="flex flex-col items-start gap-8">
-          <div className="flex-1 text-left z-100">
+      {/* main-content */}
+      <div className="relative max-w-7xl mx-auto w-full z-20">
+        {/* left-content */}
+        <div className="flex flex-col items-start sm:gap-[60px] gap-[32px] relative z-30">
+          {/* text */}
+          <div className="flex-1 text-left">
             <h1 className="text-[22px] max-sm:text-[16px] mb-6 max-sm:mb-4 font-bold text-[#01FF00] leading-tight">
               아직도 작심삼일을 반복하고 있나요?
             </h1>
-            <h2 className="text-[56px] max-sm:text-[36px] mb-12 max-sm:mb-8 font-bold text-white leading-tight">
+            <h2 className="text-[56px] max-sm:text-[36px] font-bold text-white leading-tight">
               4주면 인생이 바뀌는
               <br />
               AI 목표 관리 서비스
             </h2>
-            <div className="inline-flex justify-center lg:justify-start">
-              <Button size="lg" onClick={handleGetStarted} text="성장 여정 시작하기" />
+          </div>
+
+          {/* 얼리버드 신청 섹션 */}
+          <div className="flex flex-col gap-3">
+            <span className="text-[22px] max-sm:text-[16px] text-[rgba(194,196,200,0.88)] leading-relaxed">
+              지금 얼리버드 신청 시,
+              <br />
+              <span className="bg-gradient-to-r from-[#80F50E] via-[#78C1F1] to-[#CCADFD] bg-clip-text text-transparent font-bold">
+                연 24,000원 상당 AI{' '}
+              </span>
+              <span>기능을 </span>
+              <span className="text-white font-bold">무료 체험 </span>
+              <span>할 수 있어요!</span>
+            </span>
+            <div className="flex items-center">
+              <div className="px-3 bg-[rgba(112,115,124,0.22)] rounded-2xl">
+                <span className="text-[14px] max-sm:text-[12px] font-medium text-[rgba(194,196,200,0.88)]">
+                  무료 체험 기간: 10/2~10/31
+                </span>
+              </div>
             </div>
           </div>
+
+          {/* button */}
+          <div className="w-[320px] max-sm:w-[240px] justify-center lg:justify-start relative z-30">
+            <Button size="xl" variant="brand" onClick={handleGetStarted} text="얼리버드 신청하기" />
+          </div>
         </div>
-        <div className="sm:absolute sm:right-4 sm:top-[-190px] z-0 flex items-center justify-center">
+
+        {/* image-content */}
+        <div className="sm:absolute sm:right-4 sm:bottom-[-120px] z-10 flex items-center justify-center">
           <div className="relative">
             <Image src="/landing/landing-hero-1.png" alt="GROWIT App Preview" width={700} height={700} priority />
           </div>

--- a/src/shared/constants/urls.ts
+++ b/src/shared/constants/urls.ts
@@ -1,0 +1,5 @@
+export const urls = {
+  tumblbug: 'https://tumblbug.com/growit',
+  termsOfService: 'https://cerulean-parakeet-755.notion.site/215bf989e8858057b821f652d6d0a2d1',
+  customerInfo: 'https://cerulean-parakeet-755.notion.site/215bf989e885808d8df7dfaa21f80250',
+};


### PR DESCRIPTION
### 작업내용
- 랜딩페이지에 얼리버드 혜택 관련 내용을 추가
- footer 에 `개인정보처리방침`, `이용약관` 링크 연결
- figma 링크 : https://www.figma.com/design/KqMly1x54pjD7yrGNnrS7m/-%EA%B7%B8%EB%A1%9C%EC%9E%87-Dev?node-id=2625-27181&t=wxrAFVOeTF3y36Ym-11

<img width="1504" height="748" alt="스크린샷 2025-09-12 오후 10 18 36" src="https://github.com/user-attachments/assets/46529670-b40c-482b-b7ed-a34bc600c24c" />
