### PR TITLE
[Feat] : GNB 시스템 개선 및 랜딩페이지 헤더 개선

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,7 +34,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${pretendard.variable} font-pretendard pretendard bg-[#1C1C1E]`}>
+      <body className={`${pretendard.variable} font-pretendard pretendard bg-[#1B1C1E]`}>
         <MSWClientProvider>
           <ToastProvider>{children}</ToastProvider>
         </MSWClientProvider>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,7 +14,7 @@ export default function LandingPage() {
   return (
     <div className="min-h-screen bg-normal">
       <Header isLanding mode="logo" banner={<TumblbugBanner />} rightSection={<HeaderActions />} />
-      <div className="h-[60px]" />
+      <div className="h-[50px]" />
       <HeroSection />
       <ProblemSection />
       <SolutionSection />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,8 +13,8 @@ import { TumblbugBanner } from '@/composite/landing/banner';
 export default function LandingPage() {
   return (
     <div className="min-h-screen bg-normal">
-      <Header mode="logo" rightSection={<HeaderActions />} />
-      <TumblbugBanner />
+      <Header isLanding mode="logo" banner={<TumblbugBanner />} rightSection={<HeaderActions />} />
+      <div className="h-[60px]" />
       <HeroSection />
       <ProblemSection />
       <SolutionSection />

--- a/src/composite/landing/banner/TumblbugBanner.tsx
+++ b/src/composite/landing/banner/TumblbugBanner.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import React from 'react';
-import Badge from '@/shared/components/display/Badge';
 
 const TumblbugBanner = () => {
   const handleTumblbugClick = () => {
@@ -9,11 +8,13 @@ const TumblbugBanner = () => {
   };
 
   return (
-    <div className="relative bg-[#2E2F33] py-3">
+    <div className="relative bg-[#2E2F33] py-2">
       <meta name="theme-color" content="#2E2F33" />
       <div className="max-w-7xl mx-auto px-4 h-full">
         <div className="flex items-center justify-center gap-4 h-full">
-          <Badge type="default" size="sm" color="bg-brand-neon" textColor="text-black" label="텀블벅 단독 공개" />
+          <div className="inline-flex items-center py-1 px-3 rounded-2xl border border-[#35D942] bg-transparent text-[#35D942] text-sm font-medium whitespace-nowrap">
+            텀블벅 단독 공개
+          </div>
           <span className="text-[#E1DEE8] text-md max-sm:text-xs font-medium line-clamp-2">
             그로잇의 AI 기능을 훨씬 합리적인 가격으로 경험해보세요.
           </span>

--- a/src/composite/landing/banner/TumblbugBanner.tsx
+++ b/src/composite/landing/banner/TumblbugBanner.tsx
@@ -9,11 +9,12 @@ const TumblbugBanner = () => {
   };
 
   return (
-    <div className="relative bg-[#2E2F33] py-4">
+    <div className="relative bg-[#2E2F33] py-3">
+      <meta name="theme-color" content="#2E2F33" />
       <div className="max-w-7xl mx-auto px-4 h-full">
         <div className="flex items-center justify-center gap-4 h-full">
-          <Badge type="default" size="md" color="bg-brand-neon" textColor="text-black" label="텀블벅 단독 공개" />
-          <span className="text-[#E1DEE8] text-md max-sm:text-xs font-medium">
+          <Badge type="default" size="sm" color="bg-brand-neon" textColor="text-black" label="텀블벅 단독 공개" />
+          <span className="text-[#E1DEE8] text-md max-sm:text-xs font-medium line-clamp-2">
             그로잇의 AI 기능을 훨씬 합리적인 가격으로 경험해보세요.
           </span>
           <button

--- a/src/composite/landing/hero/HeroSection.tsx
+++ b/src/composite/landing/hero/HeroSection.tsx
@@ -12,7 +12,7 @@ const HeroSection = () => {
   };
 
   return (
-    <section className="relative min-h-screen flex items-center justify-center px-4 pt-8 pb-10 overflow-hidden">
+    <section className="relative min-h-screen flex items-center justify-center px-4 pt-8 max-sm:pt-24 pb-10 overflow-hidden">
       {/* Background with image overlay */}
       <div className="absolute inset-0">
         {/* Main background gradient */}

--- a/src/shared/components/layout/Header/Header.Desktop.tsx
+++ b/src/shared/components/layout/Header/Header.Desktop.tsx
@@ -59,11 +59,10 @@ export const HeaderDesktop = ({ mode = 'page', title, rightSection }: HeaderDesk
 
   return (
     <>
-      <header className="hidden sm:flex fixed z-100 left-0 w-full items-center justify-between px-[20px] py-[20px] shadow-sm border-t-[1px] border-line-normal bg-[#1B1C1E]">
+      <div className="hidden sm:flex w-full items-center justify-between px-[20px] py-[20px] shadow-sm">
         {renderLeftSection()}
         <div className="flex items-center gap-4">{rightSection || <React.Fragment />}</div>
-      </header>
-      <div className="max-sm:hidden h-[76px]" />
+      </div>
     </>
   );
 };

--- a/src/shared/components/layout/Header/Header.Mobile.tsx
+++ b/src/shared/components/layout/Header/Header.Mobile.tsx
@@ -27,7 +27,7 @@ export const HeaderMobile = ({ mode = 'page', title, rightSection }: HeaderMobil
 
   return (
     <>
-      <header className="sm:hidden fixed left-0 w-full bg-[#1C1C1E] border-b-[1px] border-line-normal z-100">
+      <div className="sm:hidden">
         {mode === 'logo' ? (
           <div className="flex items-center justify-between px-4 py-3">
             <Image src="/logo-text.svg" alt="Growit" height={32} width={100} />
@@ -50,8 +50,7 @@ export const HeaderMobile = ({ mode = 'page', title, rightSection }: HeaderMobil
             <div className="flex items-center gap-3 min-w-[40px] h-[40px]">{rightSection}</div>
           </div>
         )}
-      </header>
-      <div className="sm:hidden h-[60px]" />
+      </div>
     </>
   );
 };

--- a/src/shared/components/layout/Header/index.tsx
+++ b/src/shared/components/layout/Header/index.tsx
@@ -1,19 +1,45 @@
+'use client';
+
 import { HeaderDesktop, HeaderMode } from './Header.Desktop';
 import { HeaderMobile } from './Header.Mobile';
 import { HeaderBackButton } from './Header.Mobile';
+import { useEffect, useState } from 'react';
 
 interface HeaderProps {
   mode?: HeaderMode;
   title?: string;
   rightSection?: React.ReactNode;
+  banner?: React.ReactNode;
+  isLanding?: boolean;
 }
 
-const Header = ({ mode = 'page', title, rightSection }: HeaderProps) => {
+const Header = ({ mode = 'page', title, rightSection, banner, isLanding = false }: HeaderProps) => {
+  const [isScrolled, setIsScrolled] = useState(false);
+
+  useEffect(() => {
+    if (!isLanding) return;
+
+    const handleScroll = () => {
+      const scrollY = window.scrollY;
+      setIsScrolled(scrollY > 50); // 50px 스크롤 시 배경색 변경
+    };
+
+    window.addEventListener('scroll', handleScroll);
+    return () => window.removeEventListener('scroll', handleScroll);
+  }, [isLanding]);
+
+  const headerClasses = isLanding
+    ? `fixed z-100 left-0 w-full transition-all duration-300 border-b-[1px] border-line-normal ${
+        isScrolled ? 'bg-[#1B1C1E]' : 'bg-transparent border-b-0'
+      }`
+    : 'fixed z-100 left-0 w-full border-b-[1px] border-line-normal bg-[#1B1C1E]';
+
   return (
-    <>
+    <header className={headerClasses}>
+      {banner && <div className="w-full">{banner}</div>}
       <HeaderDesktop mode={mode} title={title} rightSection={rightSection} />
       <HeaderMobile mode={mode} title={title} rightSection={rightSection} />
-    </>
+    </header>
   );
 };
 


### PR DESCRIPTION
### 작업사항
- 디자인시스템 Header 에 `banner` props 추가
    - `banner` 에 상위베너를 넘기면 됨
- 텀블벅베너를 Header 상단으로 옮김
- 처음 페이지 랜더 시 Header 는 투명
<img width="1399" height="228" alt="스크린샷 2025-09-13 오후 10 32 47" src="https://github.com/user-attachments/assets/0e20ce33-1f93-4bfb-a40a-2e183bbd9a1f" />
<img width="400" height="400" alt="스크린샷 2025-09-13 오후 10 32 47" src="https://github.com/user-attachments/assets/5d3c2fc6-6279-4730-a3ab-98e3b02747e0" />
