### PR TITLE
[Hotfix]: 잘못된 url 로 얼리버드 신청하는 문제 해결

### DIFF
--- a/src/feature/customerEvent/earlyBirdModal/api/api.ts
+++ b/src/feature/customerEvent/earlyBirdModal/api/api.ts
@@ -12,7 +12,7 @@ interface EarlyBirdEventResponse {
 
 export async function postEarlyBirdEvent(request: EarlyBirdEventRequest) {
   const response = await axios.post<EarlyBirdEventResponse>(
-    `${process.env.NEXT_PUBLIC_API_URL}externals/invitations`,
+    `${process.env.NEXT_PUBLIC_API_URL}/externals/invitations`,
     request,
     {
       headers: {


### PR DESCRIPTION
<img width="802" height="510" alt="스크린샷 2025-09-15 오전 12 12 01" src="https://github.com/user-attachments/assets/66374321-898c-456d-b448-4a2cdf9749f3" />
