### PR TITLE
FIX: 홈 화면 레이아웃 깨짐 방지 및 모바일뷰로 제한

### DIFF
--- a/src/app/(home)/home/page.tsx
+++ b/src/app/(home)/home/page.tsx
@@ -23,7 +23,7 @@ export default function MainPage() {
                   <div className="max-sm:mx-[20px] sm:mx-[40px] mt-[32px] pb-3">
                     <CheerMessageCard />
                   </div>
-                  <div className="flex max-sm:flex-col mt-8 sm:flex-1 max-sm:mb-[170px] sm:mb-[80px]">
+                  <div className="flex flex-col mt-8 flex-1 mb-[80px]">
                     <div className="flex flex-col flex-1 max-sm:mx-[20px] sm:mx-[40px] sm:gap-[48px] max-sm:gap-[24px]">
                       <GoalBanner />
                       <WeeklyPlanBoard />

--- a/src/app/(home)/layout.tsx
+++ b/src/app/(home)/layout.tsx
@@ -12,7 +12,7 @@ export default function HomePageLayout({ children }: HomeLayoutProps) {
   useAutoLogout();
 
   return (
-    <div className="flex flex-1 max-sm:flex-col">
+    <div className="flex flex-1 max-sm:flex-col max-w-md mx-auto">
       <NavigationBar />
       <NotifyOnboardModal />
       <div className="flex flex-1 sm:flex-col overflow-x-hidden">{children}</div>

--- a/src/feature/goal/weeklyGoalBanner/index.tsx
+++ b/src/feature/goal/weeklyGoalBanner/index.tsx
@@ -1,6 +1,6 @@
 import { Goal } from '@/shared/type/goal';
 import { WeeklyGoalBannerMobile } from './components/WeeklyGoalBanner.mobile';
-import { WeeklyGoalBannerDesktop } from './components/WeeklyGoalBanner.desktop';
+//import { WeeklyGoalBannerDesktop } from './components/WeeklyGoalBanner.desktop';
 
 interface WeeklyGoalBannerProps {
   goal: Goal;
@@ -9,12 +9,12 @@ interface WeeklyGoalBannerProps {
 export const WeeklyGoalBanner = ({ goal }: WeeklyGoalBannerProps) => {
   return (
     <>
-      <div className="block sm:hidden">
+      <div className="block">
         <WeeklyGoalBannerMobile goal={goal} />
       </div>
-      <div className="hidden sm:block">
+      {/* <div className="hidden sm:block">
         <WeeklyGoalBannerDesktop goal={goal} />
-      </div>
+      </div> */}
     </>
   );
 };

--- a/src/feature/home/AIMentorCard.tsx
+++ b/src/feature/home/AIMentorCard.tsx
@@ -22,8 +22,8 @@ export const AIMentorCard = ({ aiMentor, aiMentorAdvice }: AIMentorCardProps) =>
   return (
     <>
       <p className="body-1-bold text-label-neutral">{aiMentorName}의 조언</p>
-      <div className="relative pt-6 min-w-[335px] min-h-[180px] px-4 rounded-2xl overflow-hidden">
-        <Image src={imagePath} alt="ai-mentor-advice" fill className={`object-fit object-top`} />
+      <div className="relative pt-6 max-w-md min-h-[180px] px-4 rounded-2xl overflow-hidden">
+        <Image src={imagePath} alt="ai-mentor-advice" fill className={`object-cover object-top`} />
         <div className="flex flex-col gap-3 relative z-50">
           <h2 className="headline-1-bold text-white">{aiMentorAdvice.message}</h2>
           <button

--- a/src/feature/home/GrorongCard.tsx
+++ b/src/feature/home/GrorongCard.tsx
@@ -11,8 +11,8 @@ export const GrorongCard = ({ mood, message, saying }: GrorongCardProps) => {
   return (
     <>
       <p className="body-1-bold text-label-neutral mb-1">그로롱의 한마디</p>
-      <div className="relative pt-6 min-w-[335px] min-h-[180px] px-4 pb-24 rounded-2xl overflow-hidden">
-        <Image src={imagePath} alt="grorong-advice" fill className={`object-fit object-top`} />
+      <div className="relative pt-6 max-w-md min-h-[180px] px-4 pb-24 rounded-2xl overflow-hidden">
+        <Image src={imagePath} alt="grorong-advice" fill className={`object-cover object-top`} />
         <div className="relative z-10">
           <h2 className="headline-1-bold text-white">{saying}</h2>
           <ToolTip text={message} position="bottom-left" />

--- a/src/shared/components/layout/Navigation/BottomNavigation.tsx
+++ b/src/shared/components/layout/Navigation/BottomNavigation.tsx
@@ -22,7 +22,7 @@ export const BottomNavigation = () => {
   }
 
   return (
-    <nav className="fixed z-100 bottom-0 w-full md:hidden p-2 flex items-center justify-around bg-normal border-t-[1px] border-t-[#70737C47]">
+    <nav className="fixed z-100 bottom-0 max-w-md mx-auto w-full p-2 flex items-center justify-around bg-normal border-t-[1px] border-t-[#70737C47]">
       {NAVIGATION_ROUTES_MOBILE.map(item => {
         const active = isActive(item.path);
         const IconComponent = active ? item.activeIcon : item.inActiveIcon;

--- a/src/shared/components/layout/Navigation/index.tsx
+++ b/src/shared/components/layout/Navigation/index.tsx
@@ -2,7 +2,7 @@
 
 import { usePathname } from 'next/navigation';
 import { BottomNavigation } from './BottomNavigation';
-import { SideNaviagation } from './SideNavigation';
+//import { SideNaviagation } from './SideNavigation';
 import { shouldHiddenNavigation } from '@/shared/constants/routes';
 
 const NavigationBar = () => {
@@ -12,7 +12,7 @@ const NavigationBar = () => {
   }
   return (
     <>
-      <SideNaviagation />
+      {/* <SideNaviagation /> */}
       <BottomNavigation />
     </>
   );


### PR DESCRIPTION
1. 랜딩페이지와 로그인 화면을 제외한 컴포넌트들에 영향을 주는 (home)/layout.tsx에 최대 넓이를 md(448px)로 주고, 이미지를 감싸는 태그에도 동일한 넓이 제한을 주어 이미지가 늘어나는 것을 방지해보았습니다.

2. 데스크탑 뷰에서 렌더링되는 컴포넌트들은 주석 처리해놓았습니다. 
<img width="866" height="856" alt="스크린샷 2025-09-29 오후 11 25 52" src="https://github.com/user-attachments/assets/611edc8d-ebfc-44fb-8d2e-a4b4de4b2b1b" />
