### PR TITLE
hotfix: 목표생성 페이지 레이아웃 깨지는 문제 해결

### DIFF
--- a/src/app/(home)/home/create-goal/layout.tsx
+++ b/src/app/(home)/home/create-goal/layout.tsx
@@ -1,0 +1,7 @@
+interface HomeLayoutProps {
+  children?: React.ReactNode;
+}
+
+export default function CreateGoalLayout({ children }: HomeLayoutProps) {
+  return <div className="flex flex-1 max-w-md">{children}</div>;
+}

--- a/src/app/(home)/home/create-goal/page.tsx
+++ b/src/app/(home)/home/create-goal/page.tsx
@@ -4,7 +4,7 @@ import { CreateGoalFormFunnel } from '@/composite/create-goal';
 
 export default function CreateGoalPage() {
   return (
-    <main className="flex w-full flex-col inset-y-auto overflow-y-auto">
+    <main className="flex flex-1 flex-col inset-y-auto overflow-y-auto">
       <CreateGoalFormFunnel />
     </main>
   );

--- a/src/composite/create-goal/createGoalFormFunnel/CreateGoalFormFunnel.tsx
+++ b/src/composite/create-goal/createGoalFormFunnel/CreateGoalFormFunnel.tsx
@@ -42,7 +42,7 @@ const CreateGoalFormFunnelContent = () => {
   };
 
   return (
-    <div className="flex flex-col">
+    <div className="flex flex-col flex-1">
       <CreateGoalFormElement.Provider>
         <FunnelHeaderProvider>
           <FunnelHeader currentStep={currentStepIndex} totalSteps={totalSteps} onBack={handleBack} />

--- a/src/composite/create-goal/createGoalFormFunnel/components/GuideMessage.tsx
+++ b/src/composite/create-goal/createGoalFormFunnel/components/GuideMessage.tsx
@@ -64,7 +64,7 @@ export const GuideMessage = ({ text, highlight, status = 'default' }: GuideMessa
           </div>
         </div>
         <div className="relative flex-shrink-0">
-          <div className="block sm:hidden">
+          <div className="block">
             <Image
               src={`/image/grorong-right-${status}.png`}
               alt="그로롱"

--- a/src/composite/create-goal/createGoalFormFunnel/components/Step0Onboarding.tsx
+++ b/src/composite/create-goal/createGoalFormFunnel/components/Step0Onboarding.tsx
@@ -75,7 +75,7 @@ export const Step0Onboarding = ({ onNext }: Step0OnboardingProps) => {
 
       {/* Bottom Actions */}
       <div className="h-[150px]" />
-      <div className="fixed bottom-0 left-0 right-0 p-[20px] border-gray-800 sm:hidden">
+      <div className="fixed bottom-0 left-0 right-0 p-[20px] border-gray-800 max-w-md mx-auto">
         <Button size="xl" text="목표 설정하기" onClick={handleGoalSetting} className="w-full" />
         <div className="h-[20px]" />
         <Button

--- a/src/composite/create-goal/createGoalFormFunnel/components/Step5Summary.tsx
+++ b/src/composite/create-goal/createGoalFormFunnel/components/Step5Summary.tsx
@@ -10,6 +10,7 @@ import { useEffect } from 'react';
 import { useFunnelHeader } from '@/shared/components/layout/FunnelHeader';
 import { CreateGoalResponseData } from '@/feature/goal/confimGoal/api';
 import { MentorCharacterType } from '@/feature/goal/mentorCharacterCard';
+import Image from 'next/image';
 
 interface Step5SummaryProps {
   onNext: () => void;
@@ -74,7 +75,7 @@ export const Step5Summary = ({ onNext, createGoalResult }: Step5SummaryProps) =>
   }, []);
 
   return (
-    <div className="relative h-[100dvh] flex flex-col md:h-screen bg-[#1B1C1E] overflow-hidden">
+    <div className="flex flex-1 flex-col bg-[#1B1C1E] overflow-hidden">
       {/* 백그라운드 이미지 */}
       <div
         className="absolute inset-0 w-full h-full"
@@ -85,6 +86,9 @@ export const Step5Summary = ({ onNext, createGoalResult }: Step5SummaryProps) =>
           backgroundRepeat: 'no-repeat',
         }}
       />
+      <div className="absolute inset-0 z-0">
+        <Image src={getBackgroundImage()} alt="Background" fill className="object-cover" priority />
+      </div>
 
       {/* 컨텐츠 */}
       <div className="relative z-10 flex flex-1 flex-col">
@@ -96,7 +100,7 @@ export const Step5Summary = ({ onNext, createGoalResult }: Step5SummaryProps) =>
         </div>
 
         {/* 메인 컨텐츠 영역 */}
-        <div className="flex-1 flex flex-col items-center justify-end px-5 pb-[80px]">
+        <div className="flex-1 flex flex-col items-center justify-end px-5 pb-[40px]">
           <div className="w-full max-w-[335px]">
             {/* 목표 정보 카드 */}
             <div className="bg-[#0F0F10] border border-[rgba(112,115,124,0.32)] rounded-lg p-5 space-y-4">
@@ -140,9 +144,7 @@ export const Step5Summary = ({ onNext, createGoalResult }: Step5SummaryProps) =>
         </div>
 
         {/* 하단 버튼 */}
-        <div className="px-5 pb-8">
-          <FunnelNextButton onClick={onNext} variant="brand" text="여정 시작하기" />
-        </div>
+        <FunnelNextButton onClick={onNext} variant="brand" text="여정 시작하기" />
       </div>
     </div>
   );

--- a/src/shared/components/layout/FunnelHeader/FunnelHeader.tsx
+++ b/src/shared/components/layout/FunnelHeader/FunnelHeader.tsx
@@ -41,39 +41,11 @@ export const FunnelHeader = ({
 
   return (
     <>
-      {/* Desktop Header */}
-      <div
-        className={`max-sm:hidden fixed top-0 left-[88px] right-0 z-50 ${currentStep === 1 ? 'transparent' : 'bg-[#1C1C1E]'}`}
-      >
-        <div className="flex items-center justify-between px-4 py-3">
-          <button
-            onClick={handleBack}
-            className="flex items-center justify-center w-10 h-10 rounded-lg hover:bg-gray-700 transition-colors"
-            aria-label="뒤로가기"
-          >
-            <ChevronLeft className="w-6 h-6 text-white" />
-          </button>
-          <div className="flex-1 text-center">
-            <h1 className="text-base font-semibold text-white">{title}</h1>
-          </div>
-          <div className="text-white text-sm min-w-[40px] text-right" />
-        </div>
-        {currentStep > 1 && (
-          <div className="w-full px-4">
-            <div className="h-1 bg-[#70737C38] rounded-full">
-              <div
-                className="h-full bg-[#3AEE49] rounded-full transition-all duration-300"
-                style={{ width: `${(currentStep / totalSteps) * 100}%` }}
-              />
-            </div>
-          </div>
-        )}
-      </div>
       <div className="max-sm:hidden h-[65px]" />
 
       {/* Mobile Header */}
       <div
-        className={`sm:hidden fixed top-0 left-0 right-0 z-50 ${currentStep === 1 ? 'bg-transparent' : 'bg-[#1C1C1E]'}`}
+        className={`fixed top-0 left-0 right-0 z-50 max-w-md mx-auto ${currentStep === 1 ? 'bg-transparent' : 'bg-[#1C1C1E]'}`}
       >
         <div className="flex items-center justify-between px-4 py-3">
           <button

--- a/src/shared/components/layout/FunnelNextButton/index.tsx
+++ b/src/shared/components/layout/FunnelNextButton/index.tsx
@@ -20,26 +20,16 @@ export const FunnelNextButton = ({
   variant = 'primary',
 }: FunnelNextButtonProps) => {
   return (
-    <>
-      {/* Desktop: 인라인 버튼 */}
-      <div className="hidden sm:flex justify-end">
-        <div className="flex justify-end">
-          <Button size="lg" type="button" text={text} variant={variant} disabled={disabled} onClick={onClick} />
-        </div>
-      </div>
-
-      {/* Mobile: 하단 고정 버튼 */}
-      <div className="fixed bottom-0 left-0 right-0 p-[20px] border-gray-800 sm:hidden">
-        <Button
-          size="lg"
-          type={type}
-          text={text}
-          variant={variant}
-          disabled={disabled}
-          onClick={onClick}
-          className="w-full"
-        />
-      </div>
-    </>
+    <div className="fixed bottom-0 left-0 right-0 p-[20px] border-gray-800 max-w-md mx-auto">
+      <Button
+        size="lg"
+        type={type}
+        text={text}
+        variant={variant}
+        disabled={disabled}
+        onClick={onClick}
+        className="w-full"
+      />
+    </div>
   );
 };


### PR DESCRIPTION
### 해결사항
- flex, block 을 혼용해서 사용하면서 layout 의 padding 속성이 버튼을 가리는 문제 발생
- 해당 레거시 코드 제거하고 버튼 표시 확인
- ticketLink : https://www.notion.so/282bf989e88580e7ace6e99d1a56fd1e?source=copy_link

<img width="877" height="664" alt="스크린샷 2025-10-04 오후 5 44 00" src="https://github.com/user-attachments/assets/1a0de8a3-4497-4713-acb1-90c4a31fdb0a" />
