### PR TITLE
fix(DEVS-12): align home matrix design tweaks with Figma

### DIFF
--- a/src/feature/todo/todoList/components/CategoryCard.tsx
+++ b/src/feature/todo/todoList/components/CategoryCard.tsx
@@ -54,7 +54,7 @@ const TodoItem = ({
 export const CategoryCard = ({ title, accentColor, bgStyle, todos, onToggle, onEdit, onAdd, onCardClick }: CategoryCardProps) => {
   return (
     <div
-      className={`flex-1 rounded-xl p-4 flex flex-col gap-3 min-w-[calc(50%-4px)] min-h-[200px] cursor-pointer ${bgStyle || 'bg-[#1C1917]'}`}
+      className={`flex-1 rounded-3xl p-4 flex flex-col gap-3 min-w-[calc(50%-4px)] min-h-[200px] cursor-pointer shadow-[0_2px_4px_rgba(0,0,0,0.04),0_1px_2px_rgba(0,0,0,0.06),0_0_1px_rgba(0,0,0,0.06)] ${bgStyle || 'bg-[#1C1917]'}`}
       onClick={onCardClick}
     >
       {/* Header */}
@@ -64,10 +64,12 @@ export const CategoryCard = ({ title, accentColor, bgStyle, todos, onToggle, onE
         </span>
         <button
           onClick={(e) => { e.stopPropagation(); onAdd?.(); }}
-          className="w-5 h-5 flex items-center justify-center text-[#A1A1A1] hover:text-white transition-colors"
+          className="w-6 h-6 flex items-center justify-center text-[#A1A1A1] hover:text-white transition-colors"
           aria-label={`${title} 투두 추가`}
         >
-          <span className="text-base leading-none">+</span>
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+            <path d="M8 3.5V12.5M3.5 8H12.5" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+          </svg>
         </button>
       </div>
 

--- a/src/feature/todo/todoList/components/CategoryDetailView.tsx
+++ b/src/feature/todo/todoList/components/CategoryDetailView.tsx
@@ -166,9 +166,6 @@ const DetailTodoItem = ({
           </div>
         )}
       </div>
-      <span className="text-xs leading-[133%] text-[#737373] shrink-0 pt-1">
-        AM 10:45
-      </span>
     </div>
   );
 };

--- a/src/feature/todo/todoList/components/MatrixView.tsx
+++ b/src/feature/todo/todoList/components/MatrixView.tsx
@@ -13,10 +13,10 @@ interface MatrixViewProps {
 }
 
 const CATEGORY_CONFIG = {
-  NOW: { title: '빨리 끝내기', accentColor: '#FF6467', bgStyle: 'bg-gradient-to-b from-[#2A1A2E] to-[#1C1917]' },
+  NOW: { title: '빨리 끝내기', accentColor: '#FF6467', bgStyle: 'bg-[#1D161E]' },
   STEADY: { title: '천천히 끝내기', accentColor: '#FF8904', bgStyle: 'bg-[#1C1917]' },
-  SKIP: { title: '넘겨도', accentColor: '#51A2FF', bgStyle: 'bg-gradient-to-b from-[#1A1E2E] to-[#1C1917]' },
-  DELETE: { title: '지워도', accentColor: '#ABAB9C', bgStyle: 'bg-[#1C1917]' },
+  SKIP: { title: '넘겨도', accentColor: '#51A2FF', bgStyle: 'bg-[#101828]' },
+  DELETE: { title: '지워도', accentColor: '#ABAB9C', bgStyle: 'bg-[#18181B]' },
 } as const;
 
 export const MatrixView = ({ groups, onToggle, onEdit, onAdd, onCardClick }: MatrixViewProps) => {

--- a/src/feature/todo/todoList/components/TodoListEmpty.tsx
+++ b/src/feature/todo/todoList/components/TodoListEmpty.tsx
@@ -6,9 +6,7 @@ export const TodoListEmpty = () => {
     <div className="flex flex-col gap-[28px] mt-[20px] mb-[20px]">
       <div className="flex flex-col items-center justify-center px-0 py-[16px]">
         <p className="text-[15px] font-normal text-[#878a93] leading-[1.6] tracking-[0.2175px] text-center">
-          현재 등록된 투두가 없습니다.
-          <br />
-          새로운 투두를 만들어보세요!
+          등록된 투두가 없어요
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary
홈 매트릭스 뷰의 작은 디자인 갭을 Figma 시안 (node 15-2216)과 맞춥니다. 사용자가 즉시 보는 4가지 차이만 다루는 작은 PR입니다.

## Changes
- **빈 상태 카피**: `"현재 등록된 투두가 없습니다.\n새로운 투두를 만들어보세요!"` → `"등록된 투두가 없어요"` (티켓 본문 표기)
- **카테고리 카드 배경**: gradient → Figma 단색 매칭
  - NOW `#1D161E` (mauve-900)
  - STEADY `#1C1917` (stone-900) — 그대로
  - SKIP `#101828` (gray-900)
  - DELETE `#18181B` (zinc-900)
- **카드 둥글기**: `rounded-xl` (12px) → `rounded-3xl` (24px) + Figma surface shadow 적용
- **추가 버튼**: 텍스트 `+` → 16px stroke SVG 아이콘 (Figma `add_regular` 매칭)
- **`CategoryDetailView` 시간 mock 제거**: `"AM 10:45"` 하드코딩이 모든 todo에 동일하게 노출되던 버그 제거. 정식 시간 표시는 별도 PR (datetime 사양 정해진 후)

## Out of scope (별도 트랙)
- **시간 표시 (제목/시간/Goal)**: BE `ToDo.date`가 `LocalDate` (date-only)이고, FE `GoalTodo.date`도 `'YYYY-MM-DD'` 문자열이라 datetime 표시 자체가 불가능. BE 모델 변경 + migration이 선행되어야 함 → 디자이너/PM 확인 후 별도 PR
- **시간순 정렬**: 위와 동일 (datetime 필드 선결)
- **스와이프 액션 (좌→완료/우→삭제)**: Figma annotation 명시. 별도 PR (`feat/DEVS-12-swipe-actions`)
- **카테고리 "완료/전체" 카운트, 중요 태스크 현황**: 티켓에는 명시되었으나 현재 디자인에 표기 없음 — 디자이너/PM 확인 필요

## Test plan
- [ ] `/home`에서 비어있는 날짜로 이동 → "등록된 투두가 없어요" 표시
- [ ] 매트릭스 뷰의 4 카드 배경이 Figma 색과 매칭
- [ ] 카드 둥글기 24px + 살짝 그림자
- [ ] 카드 헤더 우측 + 버튼이 SVG 아이콘
- [ ] 카테고리 카드 클릭 → 상세 화면에서 "AM 10:45" 텍스트가 사라짐 (어떤 todo도 시간 표시 없음)

## Notion
DEVS-12: https://www.notion.so/350bf989e8858078b3c1f3fcdbcd88c7

Generated with [Claude Code](https://claude.com/claude-code)