### PR TITLE
revert: restore NOW/STEADY/SKIP/DELETE todo category tokens

### DIFF
--- a/src/composite/home/todoListContainer/TodoListContainer.tsx
+++ b/src/composite/home/todoListContainer/TodoListContainer.tsx
@@ -20,7 +20,7 @@ const DAY_SWIPE_THRESHOLD = 60;
 export const TodoListContainer = () => {
   const addSheet = useBottomSheet();
   const editSheet = useBottomSheet();
-  const [addDefaultCategory, setAddDefaultCategory] = useState<TodoFormData['category']>('URGENT');
+  const [addDefaultCategory, setAddDefaultCategory] = useState<TodoFormData['category']>('NOW');
   // Figma 169:1559 — 선택된 날짜 재클릭 시 "중요 태스크 현황" 뷰로 토글
   const [showStatus, setShowStatus] = useState(false);
   // Figma 196:1611 — 매트릭스 영역 swipe 트래킹용 motion value
@@ -59,10 +59,10 @@ export const TodoListContainer = () => {
         };
 
         const handleAdd = (category?: string) => {
-          if (category === 'URGENT' || category === 'CONSISTENT' || category === 'DEFERABLE' || category === 'DELETABLE') {
+          if (category === 'NOW' || category === 'STEADY' || category === 'SKIP' || category === 'DELETE') {
             setAddDefaultCategory(category);
           } else {
-            setAddDefaultCategory('URGENT');
+            setAddDefaultCategory('NOW');
           }
           addSheet.showSheet();
         };

--- a/src/composite/home/todoListContainer/helper/index.ts
+++ b/src/composite/home/todoListContainer/helper/index.ts
@@ -9,7 +9,7 @@ export const getEditingTodoDefault = (): GoalTodo => ({
   date: format(new Date(), 'yyyy-MM-dd'),
   content: '',
   isCompleted: false,
-  category: 'URGENT',
+  category: 'NOW',
 });
 
 /** GoalTodo를 TodoFormData로 변환 */
@@ -17,7 +17,7 @@ export const convertToFormData = (todo: GoalTodo): TodoFormData => ({
   content: todo.content,
   goalId: todo.goal.id ?? null,
   repeatType: (todo.routine?.repeatType as FormRepeatType) ?? 'none',
-  category: todo.category ?? 'URGENT',
+  category: todo.category ?? 'NOW',
   date: todo.date,
   time: todo.time ?? undefined,
   routineDuration: todo.routine?.duration,

--- a/src/feature/todo/calendar/utils/todoIndicators.ts
+++ b/src/feature/todo/calendar/utils/todoIndicators.ts
@@ -4,18 +4,18 @@ type Indicators = Record<string, (string | null | undefined)[] | undefined>;
 
 /**
  * Figma 196:1610 calendar-day DS 주석:
- *   - 인디케이터 2개만 노출: 긴급(URGENT), 꾸준히(CONSISTENT)
+ *   - 인디케이터 2개만 노출: 긴급(NOW), 꾸준히(STEADY)
  *   - 모두 완료 시 opacity 100%, 미완료 항목 있으면 opacity 40%
- *   - DEFERABLE/DELETABLE은 인디케이터 없음
+ *   - SKIP/DELETE는 인디케이터 없음
  */
-const INDICATOR_CATEGORIES: TodoCategory[] = ['URGENT', 'CONSISTENT'];
+const INDICATOR_CATEGORIES: TodoCategory[] = ['NOW', 'STEADY'];
 
 // Figma 196:1605 calendar Indicators — color/red/500, color/amber/500
 const CATEGORY_BASE_COLOR: Record<TodoCategory, string> = {
-  URGENT: '#FB2C36',
-  CONSISTENT: '#FE9A00',
-  DEFERABLE: '#51A2FF',
-  DELETABLE: '#A1A1A1',
+  NOW: '#FB2C36',
+  STEADY: '#FE9A00',
+  SKIP: '#51A2FF',
+  DELETE: '#A1A1A1',
 };
 
 // 8자리 hex alpha — 40% ≈ 0x66, 100% = ff

--- a/src/feature/todo/todoBottomSheet/components/content/mainView/MainView.tsx
+++ b/src/feature/todo/todoBottomSheet/components/content/mainView/MainView.tsx
@@ -14,10 +14,10 @@ import { getProgressGoals } from '@/model/goal/api';
 import { cn } from '@/shared/lib/utils';
 
 const CATEGORY_OPTIONS = [
-  { value: 'URGENT' as const, label: '긴급', color: '#FF6467' },
-  { value: 'CONSISTENT' as const, label: '꾸준히', color: '#FF8904' },
-  { value: 'DEFERABLE' as const, label: '넘겨도', color: '#51A2FF' },
-  { value: 'DELETABLE' as const, label: '지워도', color: '#A1A1A1' },
+  { value: 'NOW' as const, label: '긴급', color: '#FF6467' },
+  { value: 'STEADY' as const, label: '꾸준히', color: '#FF8904' },
+  { value: 'SKIP' as const, label: '넘겨도', color: '#51A2FF' },
+  { value: 'DELETE' as const, label: '지워도', color: '#A1A1A1' },
 ];
 
 interface MainViewProps {

--- a/src/feature/todo/todoBottomSheet/form/TodoFormProvider.tsx
+++ b/src/feature/todo/todoBottomSheet/form/TodoFormProvider.tsx
@@ -63,7 +63,7 @@ export const TodoFormProvider = ({ mode, values, selectedDate, todoId, onClose, 
     () => ({
       ...TODO_DEFAULT_VALUES,
       date: initialDateString,
-      category: defaultCategory || 'URGENT',
+      category: defaultCategory || 'NOW',
     }),
     [initialDateString, defaultCategory]
   );

--- a/src/feature/todo/todoBottomSheet/form/todoFormSchema.ts
+++ b/src/feature/todo/todoBottomSheet/form/todoFormSchema.ts
@@ -35,7 +35,7 @@ export const todoFormSchema = z
     repeatType: repeatTypeSchema,
 
     /** 카테고리 */
-    category: z.enum(['URGENT', 'CONSISTENT', 'DEFERABLE', 'DELETABLE']),
+    category: z.enum(['NOW', 'STEADY', 'SKIP', 'DELETE']),
 
     /** 투두 날짜 (YYYY-MM-DD 형식) */
     date: z.string().min(1, '날짜를 선택해주세요'),

--- a/src/feature/todo/todoBottomSheet/types.ts
+++ b/src/feature/todo/todoBottomSheet/types.ts
@@ -39,7 +39,7 @@ export interface TodoFormData {
   content: string;
   goalId: string | null;
   repeatType: FormRepeatType;
-  category: 'URGENT' | 'CONSISTENT' | 'DEFERABLE' | 'DELETABLE';
+  category: 'NOW' | 'STEADY' | 'SKIP' | 'DELETE';
   /** 투두 날짜 (YYYY-MM-DD 형식) */
   date: string;
   /**
@@ -55,7 +55,7 @@ export const TODO_DEFAULT_VALUES: TodoFormData = {
   content: '',
   goalId: null,
   repeatType: 'none',
-  category: 'URGENT',
+  category: 'NOW',
   date: '',
   time: undefined,
   routineDuration: undefined,

--- a/src/feature/todo/todoList/TodoList.tsx
+++ b/src/feature/todo/todoList/TodoList.tsx
@@ -14,7 +14,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { todoListQueryKeys } from '@/model/todo/todoList/queryKeys';
 import { transformTodosData, groupTodosByCategory } from './helper';
 
-type CategoryType = 'URGENT' | 'CONSISTENT' | 'DEFERABLE' | 'DELETABLE';
+type CategoryType = 'NOW' | 'STEADY' | 'SKIP' | 'DELETE';
 
 interface TodoListProps {
   selectedDate: Date;

--- a/src/feature/todo/todoList/components/CategoryDetailView.tsx
+++ b/src/feature/todo/todoList/components/CategoryDetailView.tsx
@@ -19,7 +19,7 @@ const formatTimeLabel = (time: string): string => {
   return `${isAM ? '오전' : '오후'} ${hour12}:${minute}`;
 };
 
-type CategoryType = 'URGENT' | 'CONSISTENT' | 'DEFERABLE' | 'DELETABLE';
+type CategoryType = 'NOW' | 'STEADY' | 'SKIP' | 'DELETE';
 
 interface BgLayer {
   src: string;
@@ -32,19 +32,19 @@ interface BgLayer {
  * 위에서부터 아래 순으로 stacking 되며, 마지막은 dark gradient overlay 별도.
  */
 const CATEGORY_BG_LAYERS: Record<CategoryType, BgLayer[]> = {
-  URGENT: [
+  NOW: [
     { src: '/images/detail-bg-base.jpg', anchor: 'top' },
     { src: '/images/detail-bg-mid.jpg', anchor: 'bottom' },
     { src: '/images/detail-bg-front.jpg', anchor: 'bottom' },
   ],
-  CONSISTENT: [
+  STEADY: [
     { src: '/images/detail-bg-base.jpg', anchor: 'top' },
     { src: '/images/detail-bg-mid.jpg', anchor: 'bottom' },
     { src: '/images/detail-bg-front.jpg', anchor: 'bottom' },
     { src: '/images/detail-bg-steady-1.jpg', anchor: 'top' },
     { src: '/images/detail-bg-steady-2.jpg', anchor: 'bottom' },
   ],
-  DEFERABLE: [
+  SKIP: [
     { src: '/images/detail-bg-base.jpg', anchor: 'top' },
     { src: '/images/detail-bg-mid.jpg', anchor: 'bottom' },
     { src: '/images/detail-bg-front.jpg', anchor: 'bottom' },
@@ -52,7 +52,7 @@ const CATEGORY_BG_LAYERS: Record<CategoryType, BgLayer[]> = {
     { src: '/images/detail-bg-steady-2.jpg', anchor: 'bottom' },
     { src: '/images/detail-bg-skip-1.jpg', anchor: 'bottom' },
   ],
-  DELETABLE: [
+  DELETE: [
     { src: '/images/detail-bg-base.jpg', anchor: 'top' },
     { src: '/images/detail-bg-delete-1.jpg', anchor: 'bottom' },
     { src: '/images/detail-bg-delete-2.jpg', anchor: 'bottom' },
@@ -68,25 +68,25 @@ const CATEGORY_META: Record<
     iconSrc: string;
   }
 > = {
-  URGENT: {
+  NOW: {
     title: '빨리 끝내기',
     badge: { text: '중요 · 긴급', color: '#FF383C' },
     subtitle: '컨디션이 가장 좋은 아침에 끝내세요.',
     iconSrc: '/icon/category-now.png',
   },
-  CONSISTENT: {
+  STEADY: {
     title: '천천히 끝내기',
     badge: { text: '중요 · 천천히', color: '#FF8904' },
     subtitle: '여유를 갖고 차근차근 진행하세요.',
     iconSrc: '/icon/category-steady.png',
   },
-  DEFERABLE: {
+  SKIP: {
     title: '넘겨도',
     badge: { text: '여유 · 긴급', color: '#51A2FF' },
     subtitle: '오늘 못해도 괜찮아요.',
     iconSrc: '/icon/category-skip.png',
   },
-  DELETABLE: {
+  DELETE: {
     title: '지워도',
     badge: { text: '여유 · 천천히', color: '#ABAB9C' },
     subtitle: '필요 없다면 과감히 지워도 돼요.',
@@ -197,7 +197,7 @@ const DetailTodoItem = ({
         </div>
         <div className={isMultiLine ? 'pt-0.5' : ''}>
           <CategoryMatrixIcon
-            category={(todo.category as MatrixCategory) || 'URGENT'}
+            category={(todo.category as MatrixCategory) || 'NOW'}
           />
         </div>
       </div>

--- a/src/feature/todo/todoList/components/CategoryMatrixIcon.tsx
+++ b/src/feature/todo/todoList/components/CategoryMatrixIcon.tsx
@@ -1,17 +1,17 @@
 import { CSSProperties } from 'react';
 
-export type MatrixCategory = 'URGENT' | 'CONSISTENT' | 'DEFERABLE' | 'DELETABLE';
+export type MatrixCategory = 'NOW' | 'STEADY' | 'SKIP' | 'DELETE';
 
 const CATEGORY_COLOR: Record<MatrixCategory, string> = {
-  URGENT: '#FF6467',
-  CONSISTENT: '#FFB900',
-  DEFERABLE: '#51A2FF',
-  DELETABLE: '#ABAB9C',
+  NOW: '#FF6467',
+  STEADY: '#FFB900',
+  SKIP: '#51A2FF',
+  DELETE: '#ABAB9C',
 };
 
 const INACTIVE_COLOR = '#404040';
 
-const QUADRANT_ORDER: MatrixCategory[] = ['URGENT', 'CONSISTENT', 'DEFERABLE', 'DELETABLE'];
+const QUADRANT_ORDER: MatrixCategory[] = ['NOW', 'STEADY', 'SKIP', 'DELETE'];
 
 interface CategoryMatrixIconProps {
   /** 활성 카테고리 — 해당 사분면만 카테고리 색상 */
@@ -26,7 +26,7 @@ interface CategoryMatrixIconProps {
  *
  * 외곽 프레임 size×size 의 가운데 50% 영역(inset-1/4)에 2×2 사분면을 그린다.
  * 활성 카테고리 셀만 카테고리 색상, 나머지는 #404040.
- * 사분면 순서: 좌상 URGENT → 우상 CONSISTENT → 좌하 DEFERABLE → 우하 DELETABLE.
+ * 사분면 순서: 좌상 NOW → 우상 STEADY → 좌하 SKIP → 우하 DELETE.
  */
 export const CategoryMatrixIcon = ({
   category,

--- a/src/feature/todo/todoList/components/ListView.tsx
+++ b/src/feature/todo/todoList/components/ListView.tsx
@@ -84,7 +84,7 @@ const ListTodoItem = ({
           <GoalTag name={todo.goal.name} />
         )}
         <CategoryMatrixIcon
-          category={(todo.category as MatrixCategory) || 'URGENT'}
+          category={(todo.category as MatrixCategory) || 'NOW'}
         />
       </div>
     </SwipeableRow>

--- a/src/feature/todo/todoList/components/MatrixView.tsx
+++ b/src/feature/todo/todoList/components/MatrixView.tsx
@@ -10,7 +10,7 @@ interface MatrixViewProps {
   onDelete?: (todoId: string) => void;
   onEdit?: (todo: GoalTodo) => void;
   onAdd?: (category?: string) => void;
-  onCardClick?: (category: 'URGENT' | 'CONSISTENT' | 'DEFERABLE' | 'DELETABLE') => void;
+  onCardClick?: (category: 'NOW' | 'STEADY' | 'SKIP' | 'DELETE') => void;
 }
 
 // Figma 196:1617 — color/lime/900 (#35530E) × opacity 16%
@@ -19,10 +19,10 @@ const CARD_BG = 'bg-[rgba(53,83,14,0.16)]';
 // Accent colors per Figma 196:1623, 196:1646, etc. (Pretendard SemiBold 12px)
 // Icon assets exported from Figma 196:1554 (IcChar03/04 등 디자인 시스템)
 const CATEGORY_CONFIG = {
-  URGENT: { title: '긴급', iconSrc: '/icon/category-now.png', accentColor: '#FF6467', bgStyle: CARD_BG },
-  CONSISTENT: { title: '꾸준히', iconSrc: '/icon/category-steady.png', accentColor: '#FF8904', bgStyle: CARD_BG },
-  DEFERABLE: { title: '넘겨도', iconSrc: '/icon/category-skip.png', accentColor: '#51A2FF', bgStyle: CARD_BG },
-  DELETABLE: { title: '지워도', iconSrc: '/icon/category-delete.png', accentColor: '#A1A1A1', bgStyle: CARD_BG },
+  NOW: { title: '긴급', iconSrc: '/icon/category-now.png', accentColor: '#FF6467', bgStyle: CARD_BG },
+  STEADY: { title: '꾸준히', iconSrc: '/icon/category-steady.png', accentColor: '#FF8904', bgStyle: CARD_BG },
+  SKIP: { title: '넘겨도', iconSrc: '/icon/category-skip.png', accentColor: '#51A2FF', bgStyle: CARD_BG },
+  DELETE: { title: '지워도', iconSrc: '/icon/category-delete.png', accentColor: '#A1A1A1', bgStyle: CARD_BG },
 } as const;
 
 export const MatrixView = ({ groups, onToggle, onDelete, onEdit, onAdd, onCardClick }: MatrixViewProps) => {
@@ -32,28 +32,28 @@ export const MatrixView = ({ groups, onToggle, onDelete, onEdit, onAdd, onCardCl
         <p className="text-[13px] font-medium text-[#F4F4F5]">중요</p>
         <div className="flex flex-row gap-2 flex-1 min-h-0">
           <CategoryCard
-            title={CATEGORY_CONFIG.URGENT.title}
-            iconSrc={CATEGORY_CONFIG.URGENT.iconSrc}
-            accentColor={CATEGORY_CONFIG.URGENT.accentColor}
-            bgStyle={CATEGORY_CONFIG.URGENT.bgStyle}
-            todos={groups.URGENT}
+            title={CATEGORY_CONFIG.NOW.title}
+            iconSrc={CATEGORY_CONFIG.NOW.iconSrc}
+            accentColor={CATEGORY_CONFIG.NOW.accentColor}
+            bgStyle={CATEGORY_CONFIG.NOW.bgStyle}
+            todos={groups.NOW}
             onToggle={onToggle}
             onDelete={onDelete}
             onEdit={onEdit}
-            onAdd={() => onAdd?.('URGENT')}
-            onCardClick={() => onCardClick?.('URGENT')}
+            onAdd={() => onAdd?.('NOW')}
+            onCardClick={() => onCardClick?.('NOW')}
           />
           <CategoryCard
-            title={CATEGORY_CONFIG.CONSISTENT.title}
-            iconSrc={CATEGORY_CONFIG.CONSISTENT.iconSrc}
-            accentColor={CATEGORY_CONFIG.CONSISTENT.accentColor}
-            bgStyle={CATEGORY_CONFIG.CONSISTENT.bgStyle}
-            todos={groups.CONSISTENT}
+            title={CATEGORY_CONFIG.STEADY.title}
+            iconSrc={CATEGORY_CONFIG.STEADY.iconSrc}
+            accentColor={CATEGORY_CONFIG.STEADY.accentColor}
+            bgStyle={CATEGORY_CONFIG.STEADY.bgStyle}
+            todos={groups.STEADY}
             onToggle={onToggle}
             onDelete={onDelete}
             onEdit={onEdit}
-            onAdd={() => onAdd?.('CONSISTENT')}
-            onCardClick={() => onCardClick?.('CONSISTENT')}
+            onAdd={() => onAdd?.('STEADY')}
+            onCardClick={() => onCardClick?.('STEADY')}
           />
         </div>
       </div>
@@ -62,28 +62,28 @@ export const MatrixView = ({ groups, onToggle, onDelete, onEdit, onAdd, onCardCl
         <p className="text-[13px] font-medium text-[#F4F4F5]">여유</p>
         <div className="flex flex-row gap-2 flex-1 min-h-0">
           <CategoryCard
-            title={CATEGORY_CONFIG.DEFERABLE.title}
-            iconSrc={CATEGORY_CONFIG.DEFERABLE.iconSrc}
-            accentColor={CATEGORY_CONFIG.DEFERABLE.accentColor}
-            bgStyle={CATEGORY_CONFIG.DEFERABLE.bgStyle}
-            todos={groups.DEFERABLE}
+            title={CATEGORY_CONFIG.SKIP.title}
+            iconSrc={CATEGORY_CONFIG.SKIP.iconSrc}
+            accentColor={CATEGORY_CONFIG.SKIP.accentColor}
+            bgStyle={CATEGORY_CONFIG.SKIP.bgStyle}
+            todos={groups.SKIP}
             onToggle={onToggle}
             onDelete={onDelete}
             onEdit={onEdit}
-            onAdd={() => onAdd?.('DEFERABLE')}
-            onCardClick={() => onCardClick?.('DEFERABLE')}
+            onAdd={() => onAdd?.('SKIP')}
+            onCardClick={() => onCardClick?.('SKIP')}
           />
           <CategoryCard
-            title={CATEGORY_CONFIG.DELETABLE.title}
-            iconSrc={CATEGORY_CONFIG.DELETABLE.iconSrc}
-            accentColor={CATEGORY_CONFIG.DELETABLE.accentColor}
-            bgStyle={CATEGORY_CONFIG.DELETABLE.bgStyle}
-            todos={groups.DELETABLE}
+            title={CATEGORY_CONFIG.DELETE.title}
+            iconSrc={CATEGORY_CONFIG.DELETE.iconSrc}
+            accentColor={CATEGORY_CONFIG.DELETE.accentColor}
+            bgStyle={CATEGORY_CONFIG.DELETE.bgStyle}
+            todos={groups.DELETE}
             onToggle={onToggle}
             onDelete={onDelete}
             onEdit={onEdit}
-            onAdd={() => onAdd?.('DELETABLE')}
-            onCardClick={() => onCardClick?.('DELETABLE')}
+            onAdd={() => onAdd?.('DELETE')}
+            onCardClick={() => onCardClick?.('DELETE')}
           />
         </div>
       </div>

--- a/src/feature/todo/todoList/components/WeeklyImportantStatusView.tsx
+++ b/src/feature/todo/todoList/components/WeeklyImportantStatusView.tsx
@@ -17,18 +17,18 @@ const formatTimeLabel = (time: string): string => {
   return `${isAM ? 'AM' : 'PM'} ${hour12}:${minute}`;
 };
 
-type StatusCategory = 'URGENT' | 'CONSISTENT';
+type StatusCategory = 'NOW' | 'STEADY';
 
 const STATUS_META: Record<
   StatusCategory,
   { label: string; labelColor: string; iconSrc: string }
 > = {
-  URGENT: {
+  NOW: {
     label: '긴급',
     labelColor: '#FF6467',
     iconSrc: '/icon/category-now.png',
   },
-  CONSISTENT: {
+  STEADY: {
     label: '꾸준히',
     labelColor: '#FF8904',
     iconSrc: '/icon/category-steady.png',
@@ -199,7 +199,7 @@ const StatusCard = ({
 /**
  * Figma 169:1559 — 시안1_다크_주_현황 (중요 태스크 현황).
  *
- * 선택된 날짜의 중요(URGENT)/꾸준히(CONSISTENT) 카테고리 투두를 카드 두 개로 보여주고,
+ * 선택된 날짜의 중요(NOW)/꾸준히(STEADY) 카테고리 투두를 카드 두 개로 보여주고,
  * 각 카드는 완료 비율만큼 lime-400/0.32 게이지가 차오른다.
  */
 export const WeeklyImportantStatusView = ({
@@ -209,8 +209,8 @@ export const WeeklyImportantStatusView = ({
   onEdit,
   onAdd,
 }: WeeklyImportantStatusViewProps) => {
-  const nowTodos = todos.filter(t => t.category === 'URGENT');
-  const steadyTodos = todos.filter(t => t.category === 'CONSISTENT');
+  const nowTodos = todos.filter(t => t.category === 'NOW');
+  const steadyTodos = todos.filter(t => t.category === 'STEADY');
   const importantTodos = [...nowTodos, ...steadyTodos];
   const completed = importantTodos.filter(t => t.isCompleted).length;
   const total = importantTodos.length;
@@ -231,7 +231,7 @@ export const WeeklyImportantStatusView = ({
       {/* Two cards */}
       <div className="flex gap-2 flex-1 min-h-0 items-stretch">
         <StatusCard
-          category="URGENT"
+          category="NOW"
           todos={nowTodos}
           onToggle={onToggle}
           onDelete={onDelete}
@@ -239,7 +239,7 @@ export const WeeklyImportantStatusView = ({
           onAdd={onAdd}
         />
         <StatusCard
-          category="CONSISTENT"
+          category="STEADY"
           todos={steadyTodos}
           onToggle={onToggle}
           onDelete={onDelete}

--- a/src/feature/todo/todoList/helper.ts
+++ b/src/feature/todo/todoList/helper.ts
@@ -1,12 +1,12 @@
 import { GoalTodo } from '@/shared/type/GoalTodo';
 
-export type TodoCategory = 'URGENT' | 'CONSISTENT' | 'DEFERABLE' | 'DELETABLE';
+export type TodoCategory = 'NOW' | 'STEADY' | 'SKIP' | 'DELETE';
 
 export interface CategoryGroups {
-  URGENT: GoalTodo[];
-  CONSISTENT: GoalTodo[];
-  DEFERABLE: GoalTodo[];
-  DELETABLE: GoalTodo[];
+  NOW: GoalTodo[];
+  STEADY: GoalTodo[];
+  SKIP: GoalTodo[];
+  DELETE: GoalTodo[];
 }
 
 export interface GoalGroup {
@@ -24,15 +24,15 @@ interface TodoDataItem {
  * Todo를 category별로 그룹화
  */
 export const groupTodosByCategory = (todos: GoalTodo[]): CategoryGroups => {
-  const groups: CategoryGroups = { URGENT: [], CONSISTENT: [], DEFERABLE: [], DELETABLE: [] };
+  const groups: CategoryGroups = { NOW: [], STEADY: [], SKIP: [], DELETE: [] };
 
   todos.forEach(todo => {
     const cat = todo.category;
     if (cat && cat in groups) {
       groups[cat].push(todo);
     } else {
-      // category가 없는 경우 URGENT로 분류
-      groups.URGENT.push(todo);
+      // category가 없는 경우 NOW로 분류
+      groups.NOW.push(todo);
     }
   });
 

--- a/src/model/todo/todoList/dto.ts
+++ b/src/model/todo/todoList/dto.ts
@@ -67,7 +67,7 @@ export interface TodoCountByGoal {
   todoCount: number;
 }
 
-export type TodoCategory = 'URGENT' | 'CONSISTENT' | 'DEFERABLE' | 'DELETABLE';
+export type TodoCategory = 'NOW' | 'STEADY' | 'SKIP' | 'DELETE';
 
 export interface TodoCountByCategory {
   category: TodoCategory;

--- a/src/shared/type/GoalTodo.ts
+++ b/src/shared/type/GoalTodo.ts
@@ -22,5 +22,5 @@ export interface GoalTodo {
   content: string;
   routine?: GoalTodoRoutine;
   isCompleted: boolean;
-  category?: 'URGENT' | 'CONSISTENT' | 'DEFERABLE' | 'DELETABLE';
+  category?: 'NOW' | 'STEADY' | 'SKIP' | 'DELETE';
 }


### PR DESCRIPTION
## 배경
이전 PR #286 (`fix: align todo category tokens with BE ToDoCategory enum`)에서 FE 카테고리 토큰을 BE enum과 정합시켰으나, 운영 결정으로 기존 토큰 체계를 유지하기로 변경됨.

## 변경 사항
PR #286 (커밋 `58859bc`)을 revert:

| 현재(머지됨) | 되돌릴 값 | 라벨 |
|---|---|---|
| `URGENT` | `NOW` | 긴급 |
| `CONSISTENT` | `STEADY` | 꾸준히 |
| `DEFERABLE` | `SKIP` | 넘겨도 |
| `DELETABLE` | `DELETE` | 지워도 |

## 검증
- `./node_modules/.bin/tsc --noEmit` → exit 0
- `yarn lint` → exit 0

## Test plan
- [ ] BE 측 enum 정책 결정 재확인 (기존 토큰 유지 OK 인지)
- [ ] todo 생성/수정 시 카테고리 필드 전송 동작 확인 (BE와의 인터페이스 정합)

🤖 Generated with [Claude Code](https://claude.com/claude-code)