### PR TITLE
fix: 투두 카테고리 스타일 및 카피 복원

### DIFF
--- a/src/app/customTokens.css
+++ b/src/app/customTokens.css
@@ -27,19 +27,6 @@
   --fill-brand: #58cf04;
   --bg-elevated: #1b1c1e;
   --bg-default: #09090b;
-  --category-now: #ff6467;
-  --category-steady: #ff8904;
-  --category-skip: #51a2ff;
-  --category-delete: #abab9c;
-  --category-nav-steady: #ffb900;
-  --category-panel: #171717;
-  --category-control: #ebebec;
-  --category-control-icon: #27272a;
-  --category-muted: #a1a1a1;
-  --category-subtle: #737373;
-  --category-empty: #525252;
-  --category-tab-inactive: #404040;
-  --category-section-label: #f4f4f5;
 }
 
 @theme {
@@ -79,19 +66,4 @@
   /* Background Colors */
   --color-bg-elevated: var(--bg-elevated);
   --color-bg-default: var(--bg-default);
-
-  /* Todo Category Colors */
-  --color-category-now: var(--category-now);
-  --color-category-steady: var(--category-steady);
-  --color-category-skip: var(--category-skip);
-  --color-category-delete: var(--category-delete);
-  --color-category-nav-steady: var(--category-nav-steady);
-  --color-category-panel: var(--category-panel);
-  --color-category-control: var(--category-control);
-  --color-category-control-icon: var(--category-control-icon);
-  --color-category-muted: var(--category-muted);
-  --color-category-subtle: var(--category-subtle);
-  --color-category-empty: var(--category-empty);
-  --color-category-tab-inactive: var(--category-tab-inactive);
-  --color-category-section-label: var(--category-section-label);
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -114,42 +114,6 @@ dialog::backdrop {
 }
 
 @layer utilities {
-  .category-detail-overlay {
-    background: linear-gradient(180deg, #081c32 0%, rgba(64, 85, 115, 0.25) 100%);
-  }
-
-  .category-detail-bg-base-top {
-    background: url('/images/detail-bg-base.jpg') center top / cover no-repeat;
-  }
-
-  .category-detail-bg-mid-bottom {
-    background: url('/images/detail-bg-mid.jpg') center bottom / cover no-repeat;
-  }
-
-  .category-detail-bg-front-bottom {
-    background: url('/images/detail-bg-front.jpg') center bottom / cover no-repeat;
-  }
-
-  .category-detail-bg-steady-top {
-    background: url('/images/detail-bg-steady-1.jpg') center top / cover no-repeat;
-  }
-
-  .category-detail-bg-steady-bottom {
-    background: url('/images/detail-bg-steady-2.jpg') center bottom / cover no-repeat;
-  }
-
-  .category-detail-bg-skip-bottom {
-    background: url('/images/detail-bg-skip-1.jpg') center bottom / cover no-repeat;
-  }
-
-  .category-detail-bg-delete-first {
-    background: url('/images/detail-bg-delete-1.jpg') center bottom / cover no-repeat;
-  }
-
-  .category-detail-bg-delete-second {
-    background: url('/images/detail-bg-delete-2.jpg') center bottom / cover no-repeat;
-  }
-
   .scrollbar-hidden {
     -ms-overflow-style: none;
     scrollbar-width: none;

--- a/src/feature/todo/todoBottomSheet/components/subBottomSheet/editSelectView/EditBottomSheet.tsx
+++ b/src/feature/todo/todoBottomSheet/components/subBottomSheet/editSelectView/EditBottomSheet.tsx
@@ -18,18 +18,17 @@ interface EditButtonProps {
 }
 
 const EditButton = ({ onClick, text, variant = 'danger', disabled = false }: EditButtonProps) => {
+  const textColor = variant === 'danger' ? 'text-[#FF6363]' : 'text-white';
+
   return (
-    <Button
-      size="lg"
-      variant="tertiary"
+    <button
       type="button"
       onClick={onClick}
       disabled={disabled}
-      text={text}
-      className={`h-11 shadow-xs transition-opacity disabled:opacity-40 ${
-        variant === 'danger' ? 'text-text-danger' : 'text-text-strong'
-      }`}
-    />
+      className="flex h-[44px] w-full items-center justify-center rounded-[8px] px-[18px] py-[10px] shadow-[0px_1px_2px_0px_rgba(10,13,18,0.05)] transition-opacity disabled:cursor-not-allowed disabled:opacity-40"
+    >
+      <span className={`font-bold text-[16px] leading-[1.5] tracking-[0.057px] ${textColor}`}>{text}</span>
+    </button>
   );
 };
 
@@ -64,17 +63,15 @@ export const EditBottomSheet = ({ isOpen, onClose }: EditBottomSheetProps) => {
       <BottomSheet isOpen={isOpen} showSheet={() => {}} closeSheet={isSubmitting ? () => {} : onClose} height="auto">
         <BottomSheet.Title>
           <div className="flex w-full items-center justify-end px-5 pb-4 pt-2">
-            <Button
-              size="sm"
-              layout="icon-only"
-              variant="tertiary"
+            <button
               type="button"
               onClick={onClose}
               disabled={isSubmitting}
               aria-label="수정 범위 선택 닫기"
-              className="p-0 text-label-normal transition-colors hover:text-label-strong disabled:opacity-40"
-              icon={<XIcon className="h-5 w-5" />}
-            />
+              className="text-label-normal transition-colors hover:text-label-strong disabled:opacity-40"
+            >
+              <XIcon className="h-5 w-5" />
+            </button>
           </div>
         </BottomSheet.Title>
 

--- a/src/feature/todo/todoList/category.ts
+++ b/src/feature/todo/todoList/category.ts
@@ -2,9 +2,12 @@ export const TODO_CATEGORY_ORDER = ['NOW', 'STEADY', 'SKIP', 'DELETE'] as const;
 
 export type TodoCategory = (typeof TODO_CATEGORY_ORDER)[number];
 
-export const TODO_CATEGORY_NAV_META: Record<TodoCategory, { label: string; activeClassName: string }> = {
-  NOW: { label: '긴급', activeClassName: 'bg-category-now' },
-  STEADY: { label: '꾸준히', activeClassName: 'bg-category-nav-steady' },
-  SKIP: { label: '넘겨도', activeClassName: 'bg-category-skip' },
-  DELETE: { label: '지워도', activeClassName: 'bg-category-delete' },
+export const TODO_CATEGORY_NAV_META: Record<
+  TodoCategory,
+  { label: string; activeColor: string }
+> = {
+  NOW: { label: '긴급', activeColor: '#FF6467' },
+  STEADY: { label: '꾸준히', activeColor: '#FFB900' },
+  SKIP: { label: '넘겨도', activeColor: '#51A2FF' },
+  DELETE: { label: '지워도', activeColor: '#ABAB9C' },
 };

--- a/src/feature/todo/todoList/components/CategoryCard.tsx
+++ b/src/feature/todo/todoList/components/CategoryCard.tsx
@@ -5,7 +5,6 @@ import Image from 'next/image';
 import { GoalTodo } from '@/shared/type/GoalTodo';
 import { SwipeableRow } from './SwipeableRow';
 import { TodoItemCheckbox } from './TodoItemCheckbox';
-import Button from '@/shared/components/input/Button';
 
 /** "HH:mm" → "오전/오후 h:mm" */
 const formatTimeLabel = (time: string): string => {
@@ -21,7 +20,7 @@ const formatTimeLabel = (time: string): string => {
 interface CategoryCardProps {
   title: string;
   iconSrc: string;
-  accentClassName: string;
+  accentColor: string;
   bgStyle?: string;
   todos: GoalTodo[];
   onToggle?: (todoId: string, isCompleted: boolean) => void;
@@ -65,13 +64,11 @@ const TodoItem = ({
         </div>
         <div className="flex flex-col flex-1 min-w-0 cursor-pointer" onClick={() => onEdit?.(todo)}>
           <p
-            className={`text-[14px] leading-[1.42] truncate ${
-              checked ? 'line-through text-category-muted' : 'text-text-strong'
-            }`}
+            className={`text-[14px] leading-[1.42] truncate ${checked ? 'line-through text-[#A1A1A1]' : 'text-white'}`}
           >
             {todo.content}
           </p>
-          {todo.time && <p className="text-[10px] leading-[1.33] text-category-subtle">{formatTimeLabel(todo.time)}</p>}
+          {todo.time && <p className="text-[10px] leading-[1.33] text-[#737373]">{formatTimeLabel(todo.time)}</p>}
         </div>
       </div>
     </SwipeableRow>
@@ -81,7 +78,7 @@ const TodoItem = ({
 export const CategoryCard = ({
   title,
   iconSrc,
-  accentClassName,
+  accentColor,
   bgStyle,
   todos,
   onToggle,
@@ -95,41 +92,39 @@ export const CategoryCard = ({
 
   return (
     <div
-      className={`relative flex-1 h-full rounded-[24px] flex flex-col gap-3 px-4 py-3 min-w-[calc(50%-4px)] cursor-pointer overflow-hidden shadow-[0px_2px_4px_rgba(0,0,0,0.04),0px_1px_2px_rgba(0,0,0,0.06),0px_0px_1px_rgba(0,0,0,0.06)] drop-shadow-[0px_1px_1px_rgba(10,13,18,0.05)] ${bgStyle ?? 'bg-[rgba(53,83,14,0.16)]'}`}
+      className={`relative flex-1 h-full rounded-[24px] flex flex-col gap-3 px-4 py-3 min-w-[calc(50%-4px)] cursor-pointer overflow-hidden shadow-[0px_2px_4px_rgba(0,0,0,0.04),0px_1px_2px_rgba(0,0,0,0.06),0px_0px_1px_rgba(0,0,0,0.06)] drop-shadow-[0px_1px_1px_rgba(10,13,18,0.05)] ${bgStyle ?? 'bg-[#35530E29]'}`}
       onClick={onCardClick}
     >
       {/* Header: char icon + label + count + add (Figma 196:1618) */}
       <div className="relative z-10 flex shrink-0 items-center gap-1">
         <Image src={iconSrc} alt="" width={24} height={24} className="shrink-0 select-none" priority />
         <div className="flex items-center gap-1.5 flex-1 min-w-0 text-[12px] leading-[1.33]">
-          <span className={`truncate font-semibold ${accentClassName}`}>{title}</span>
-          <span className="shrink-0 font-normal text-category-subtle">
+          <span className="font-semibold truncate" style={{ color: accentColor }}>
+            {title}
+          </span>
+          <span className="font-normal text-[#737373] shrink-0">
             {completed}/{total}
           </span>
         </div>
-        <Button
-          size="sm"
-          layout="icon-only"
-          variant="tertiary"
+        <button
           onClick={e => {
             e.stopPropagation();
             onAdd?.();
           }}
-          className="h-8 w-8 shrink-0 rounded-2xl p-2 text-category-muted transition-colors hover:text-text-strong"
+          className="flex items-center justify-center w-8 h-8 p-2 rounded-2xl text-[#A1A1A1] hover:text-white transition-colors shrink-0"
           aria-label={`${title} 투두 추가`}
-          icon={
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 16 16"
-              fill="none"
-              xmlns="http://www.w3.org/2000/svg"
-              aria-hidden="true"
-            >
-              <path d="M8 3.33V12.67M3.33 8H12.67" stroke="currentColor" strokeWidth="1.33" strokeLinecap="round" />
-            </svg>
-          }
-        />
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 16 16"
+            fill="none"
+            xmlns="http://www.w3.org/2000/svg"
+            aria-hidden="true"
+          >
+            <path d="M8 3.33V12.67M3.33 8H12.67" stroke="currentColor" strokeWidth="1.33" strokeLinecap="round" />
+          </svg>
+        </button>
       </div>
 
       {/* Todo items */}
@@ -139,7 +134,7 @@ export const CategoryCard = ({
             <TodoItem key={todo.id} todo={todo} onToggle={onToggle} onDelete={onDelete} onEdit={onEdit} />
           ))
         ) : (
-          <p className="w-full text-center text-[14px] leading-[1.42] text-category-empty">등록된 투두가 없어요</p>
+          <p className="text-[14px] leading-[1.42] text-[#525252] w-full text-center">등록된 투두가 없어요</p>
         )}
       </div>
     </div>

--- a/src/feature/todo/todoList/components/CategoryDetailView.tsx
+++ b/src/feature/todo/todoList/components/CategoryDetailView.tsx
@@ -9,7 +9,6 @@ import { TodoItemCheckbox } from './TodoItemCheckbox';
 import { CategoryMatrixIcon, MatrixCategory } from './CategoryMatrixIcon';
 import { CategoryNavigation } from './CategoryNavigation';
 import { TODO_CATEGORY_ORDER, type TodoCategory } from '../category';
-import Button from '@/shared/components/input/Button';
 
 const SWIPE_START_THRESHOLD = 12;
 const SWIPE_COMPLETE_THRESHOLD = 96;
@@ -27,7 +26,9 @@ const formatTimeLabel = (time: string): string => {
 };
 
 interface BgLayer {
-  className: string;
+  src: string;
+  /** bg-position 앵커 — 캔버스 어디에 이미지를 붙일지 */
+  anchor: 'top' | 'bottom' | 'center';
 }
 
 /**
@@ -36,38 +37,55 @@ interface BgLayer {
  */
 const CATEGORY_BG_LAYERS: Record<TodoCategory, BgLayer[]> = {
   NOW: [
-    { className: 'category-detail-bg-base-top' },
-    { className: 'category-detail-bg-mid-bottom' },
-    { className: 'category-detail-bg-front-bottom' },
+    { src: '/images/detail-bg-base.jpg', anchor: 'top' },
+    { src: '/images/detail-bg-mid.jpg', anchor: 'bottom' },
+    { src: '/images/detail-bg-front.jpg', anchor: 'bottom' },
   ],
   STEADY: [
-    { className: 'category-detail-bg-base-top' },
-    { className: 'category-detail-bg-mid-bottom' },
-    { className: 'category-detail-bg-front-bottom' },
-    { className: 'category-detail-bg-steady-top' },
-    { className: 'category-detail-bg-steady-bottom' },
+    { src: '/images/detail-bg-base.jpg', anchor: 'top' },
+    { src: '/images/detail-bg-mid.jpg', anchor: 'bottom' },
+    { src: '/images/detail-bg-front.jpg', anchor: 'bottom' },
+    { src: '/images/detail-bg-steady-1.jpg', anchor: 'top' },
+    { src: '/images/detail-bg-steady-2.jpg', anchor: 'bottom' },
   ],
   SKIP: [
-    { className: 'category-detail-bg-base-top' },
-    { className: 'category-detail-bg-mid-bottom' },
-    { className: 'category-detail-bg-front-bottom' },
-    { className: 'category-detail-bg-steady-top' },
-    { className: 'category-detail-bg-steady-bottom' },
-    { className: 'category-detail-bg-skip-bottom' },
+    { src: '/images/detail-bg-base.jpg', anchor: 'top' },
+    { src: '/images/detail-bg-mid.jpg', anchor: 'bottom' },
+    { src: '/images/detail-bg-front.jpg', anchor: 'bottom' },
+    { src: '/images/detail-bg-steady-1.jpg', anchor: 'top' },
+    { src: '/images/detail-bg-steady-2.jpg', anchor: 'bottom' },
+    { src: '/images/detail-bg-skip-1.jpg', anchor: 'bottom' },
   ],
   DELETE: [
-    { className: 'category-detail-bg-base-top' },
-    { className: 'category-detail-bg-delete-first' },
-    { className: 'category-detail-bg-delete-second' },
+    { src: '/images/detail-bg-base.jpg', anchor: 'top' },
+    { src: '/images/detail-bg-delete-1.jpg', anchor: 'bottom' },
+    { src: '/images/detail-bg-delete-2.jpg', anchor: 'bottom' },
   ],
 };
 
 const CategoryBackground = ({ category }: { category: TodoCategory }) => (
   <div className="absolute inset-0 overflow-hidden">
     {CATEGORY_BG_LAYERS[category].map((layer, index) => (
-      <div key={`${category}-${index}`} className={`absolute inset-0 ${layer.className}`} />
+      <div
+        key={`${category}-${index}`}
+        className="absolute inset-0 bg-cover bg-no-repeat"
+        style={{
+          backgroundImage: `url(${layer.src})`,
+          backgroundPosition:
+            layer.anchor === 'top'
+              ? 'center top'
+              : layer.anchor === 'bottom'
+                ? 'center bottom'
+                : 'center',
+        }}
+      />
     ))}
-    <div className="category-detail-overlay absolute inset-0" />
+    <div
+      className="absolute inset-0"
+      style={{
+        background: 'linear-gradient(180deg, #081C32 0%, rgba(64,85,115,0.25) 100%)',
+      }}
+    />
   </div>
 );
 
@@ -75,32 +93,32 @@ const CATEGORY_META: Record<
   TodoCategory,
   {
     title: string;
-    badge: { text: string; className: string };
+    badge: { text: string; color: string };
     subtitle: string;
     iconSrc: string;
   }
 > = {
   NOW: {
     title: '빨리 끝내기',
-    badge: { text: '중요 · 긴급', className: 'text-category-now' },
+    badge: { text: '긴급', color: '#FF383C' },
     subtitle: '컨디션이 가장 좋은 아침에 끝내세요.',
     iconSrc: '/icon/category-now.png',
   },
   STEADY: {
-    title: '천천히 끝내기',
-    badge: { text: '중요 · 천천히', className: 'text-category-steady' },
+    title: '꾸준히하기',
+    badge: { text: '꾸준히', color: '#FF8904' },
     subtitle: '여유를 갖고 차근차근 진행하세요.',
     iconSrc: '/icon/category-steady.png',
   },
   SKIP: {
-    title: '넘겨도',
-    badge: { text: '여유 · 긴급', className: 'text-category-skip' },
+    title: '여유롭게 끝내기',
+    badge: { text: '넘겨도', color: '#51A2FF' },
     subtitle: '오늘 못해도 괜찮아요.',
     iconSrc: '/icon/category-skip.png',
   },
   DELETE: {
-    title: '지워도',
-    badge: { text: '여유 · 천천히', className: 'text-category-delete' },
+    title: '천천히 끝내기',
+    badge: { text: '지워도', color: '#ABAB9C' },
     subtitle: '필요 없다면 과감히 지워도 돼요.',
     iconSrc: '/icon/category-delete.png',
   },
@@ -119,26 +137,21 @@ const RoutineTag = ({ routine }: { routine: GoalTodo['routine'] }) => {
   };
 
   return (
-    <span className="inline-flex items-center gap-1 rounded-xl bg-category-tab-inactive px-1 py-0.5 text-category-muted">
-      <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-        <path
-          d="M1.5 6.5C1.5 4 3.5 2 6 2c1.7 0 3.1.9 3.9 2.3M10.5 5.5C10.5 8 8.5 10 6 10c-1.7 0-3.1-.9-3.9-2.3"
-          stroke="currentColor"
-          strokeWidth="0.8"
-          strokeLinecap="round"
-        />
-        <path d="M9 2v2.5h-2.5" stroke="currentColor" strokeWidth="0.8" strokeLinecap="round" strokeLinejoin="round" />
-        <path d="M3 10V7.5h2.5" stroke="currentColor" strokeWidth="0.8" strokeLinecap="round" strokeLinejoin="round" />
+    <span className="inline-flex items-center gap-1 bg-[#404040] rounded-xl px-1 py-0.5">
+      <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
+        <path d="M1.5 6.5C1.5 4 3.5 2 6 2c1.7 0 3.1.9 3.9 2.3M10.5 5.5C10.5 8 8.5 10 6 10c-1.7 0-3.1-.9-3.9-2.3" stroke="#A1A1A1" strokeWidth="0.8" strokeLinecap="round" />
+        <path d="M9 2v2.5h-2.5" stroke="#A1A1A1" strokeWidth="0.8" strokeLinecap="round" strokeLinejoin="round" />
+        <path d="M3 10V7.5h2.5" stroke="#A1A1A1" strokeWidth="0.8" strokeLinecap="round" strokeLinejoin="round" />
       </svg>
-      <span className="text-xs leading-[133%]">{labelMap[routine.repeatType] || routine.repeatType}</span>
+      <span className="text-xs leading-[133%] text-[#A1A1A1]">{labelMap[routine.repeatType] || routine.repeatType}</span>
     </span>
   );
 };
 
 /** 목표 태그 */
 const GoalTag = ({ name }: { name: string }) => (
-  <span className="inline-flex items-center gap-1 rounded-xl bg-category-tab-inactive px-1 py-0.5">
-    <span className="text-xs leading-[133%] text-category-muted">#{name}</span>
+  <span className="inline-flex items-center gap-1 bg-[#404040] rounded-xl px-1 py-0.5">
+    <span className="text-xs leading-[133%] text-[#A1A1A1]">#{name}</span>
   </span>
 );
 
@@ -182,7 +195,10 @@ const DetailTodoItem = ({
   const isMultiLine = hasTime || hasTags;
 
   return (
-    <SwipeableRow onComplete={handleCheck} onDelete={onDelete ? () => onDelete(todo.id) : undefined}>
+    <SwipeableRow
+      onComplete={handleCheck}
+      onDelete={onDelete ? () => onDelete(todo.id) : undefined}
+    >
       <div className={`flex gap-2 py-1.5 ${isMultiLine ? 'items-start' : 'items-center'}`}>
         <div className={isMultiLine ? 'pt-0.5' : ''}>
           <TodoItemCheckbox checked={checked} onClick={handleCheck} />
@@ -190,24 +206,30 @@ const DetailTodoItem = ({
         <div className="flex-1 min-w-0 flex flex-col gap-1">
           <span
             className={`text-sm leading-[142%] font-medium cursor-pointer ${
-              checked ? 'line-through text-category-muted' : 'text-text-strong'
+              checked ? 'line-through text-[#A1A1A1]' : 'text-white'
             }`}
             onClick={() => onEdit?.(todo)}
           >
             {todo.content}
           </span>
           {hasTime && (
-            <p className="text-[12px] leading-[1.33] text-category-subtle">{formatTimeLabel(todo.time as string)}</p>
+            <p className="text-[12px] leading-[1.33] text-[#737373]">
+              {formatTimeLabel(todo.time as string)}
+            </p>
           )}
           {hasTags && (
             <div className={`flex items-center gap-1 ${checked ? 'opacity-50' : ''}`}>
               {todo.routine && <RoutineTag routine={todo.routine} />}
-              {todo.goal?.name && todo.goal.name !== '미분류' && <GoalTag name={todo.goal.name} />}
+              {todo.goal?.name && todo.goal.name !== '미분류' && (
+                <GoalTag name={todo.goal.name} />
+              )}
             </div>
           )}
         </div>
         <div className={isMultiLine ? 'pt-0.5' : ''}>
-          <CategoryMatrixIcon category={(todo.category as MatrixCategory) || 'NOW'} />
+          <CategoryMatrixIcon
+            category={(todo.category as MatrixCategory) || 'NOW'}
+          />
         </div>
       </div>
     </SwipeableRow>
@@ -238,26 +260,38 @@ const CategoryPanelCard = ({
   return (
     <div
       aria-hidden={isPreview || undefined}
-      className="flex h-fit max-h-full min-h-0 flex-col overflow-hidden rounded-2xl bg-category-panel shadow-sm"
+      className="flex h-fit max-h-full min-h-0 flex-col overflow-hidden rounded-2xl bg-[#171717] shadow-[0px_0px_1px_rgba(0,0,0,0.06),0px_1px_2px_rgba(0,0,0,0.06),0px_2px_4px_rgba(0,0,0,0.04)]"
     >
       <div className="flex h-fit max-h-full min-h-0 flex-col gap-8 px-6 pb-8 pt-6">
         <div className="flex shrink-0 flex-col gap-3">
           <div className="flex items-center gap-2">
-            <Image src={meta.iconSrc} alt="" width={24} height={24} className="shrink-0 select-none" priority />
-            <h2 className="truncate text-[20px] font-bold leading-[130%] text-white">{meta.title}</h2>
+            <Image
+              src={meta.iconSrc}
+              alt=""
+              width={24}
+              height={24}
+              className="shrink-0 select-none"
+              priority
+            />
+            <h2 className="truncate text-[20px] font-bold leading-[130%] text-white">
+              {meta.title}
+            </h2>
             <span
-              className={`shrink-0 whitespace-nowrap rounded-3xl px-2 py-1.5 text-xs font-medium leading-[134%] ${meta.badge.className}`}
+              className="shrink-0 whitespace-nowrap rounded-3xl px-2 py-1.5 text-xs font-medium leading-[134%]"
+              style={{ color: meta.badge.color }}
             >
               {meta.badge.text}
             </span>
           </div>
-          <p className="truncate text-xs leading-[133%] text-category-muted">{meta.subtitle}</p>
+          <p className="truncate text-xs leading-[133%] text-[#A1A1A1]">
+            {meta.subtitle}
+          </p>
         </div>
 
         <div
-          id={`todo-category-panel-${category.toLowerCase()}`}
-          role="tabpanel"
-          aria-labelledby={`todo-category-tab-${category.toLowerCase()}`}
+          id={isPreview ? undefined : 'todo-category-panel'}
+          role={isPreview ? undefined : 'tabpanel'}
+          aria-labelledby={isPreview ? undefined : `todo-category-tab-${category.toLowerCase()}`}
           className="flex h-fit max-h-full min-h-0 flex-[0_1_auto] flex-col gap-4 overflow-y-auto overscroll-contain"
         >
           {todos.length > 0 ? (
@@ -271,15 +305,14 @@ const CategoryPanelCard = ({
               />
             ))
           ) : (
-            <Button
-              size="sm"
-              variant="tertiary"
+            <button
               type="button"
               aria-label={`${CATEGORY_META[category].badge.text} 투두 추가`}
-              text="할 일이 없어요"
-              className="justify-start px-0 text-left text-sm text-category-subtle transition-colors hover:text-category-muted"
+              className="w-full cursor-pointer text-left text-sm text-[#737373] transition-colors hover:text-[#A1A1A1]"
               onClick={isPreview ? undefined : onAdd}
-            />
+            >
+              할 일이 없어요
+            </button>
           )}
         </div>
       </div>
@@ -487,6 +520,8 @@ export const CategoryDetailView = ({
     }, 180);
   };
 
+  const slideTransition = isSettling ? 'transform 180ms ease-out' : 'none';
+
   return (
     <AnimatePresence>
       {isOpen && (
@@ -516,48 +551,47 @@ export const CategoryDetailView = ({
         >
           {/* 상단 컨트롤은 화면에 하나만 고정 */}
           <div className="pointer-events-auto absolute inset-x-0 top-[50px] z-20 flex items-center justify-between px-5 [transform:translateZ(0)]">
-            <Button
-              size="sm"
-              layout="icon-only"
-              variant="tertiary"
+            <button
               onClick={onClose}
               aria-label="아래로 내리기"
-              className="h-10 w-10 rounded-[24px] bg-category-control p-0 text-category-control-icon"
-              icon={
-                <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-                  <path
-                    d="M3.333 6L8 10.667 12.667 6"
-                    stroke="currentColor"
-                    strokeWidth="1.5"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-              }
-            />
+              className="flex h-10 w-10 items-center justify-center rounded-[24px] bg-[#EBEBEC]"
+            >
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                <path
+                  d="M3.333 6L8 10.667 12.667 6"
+                  stroke="#27272A"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                />
+              </svg>
+            </button>
 
             <CategoryNavigation value={category} onValueChange={handleCategorySelection} />
 
-            <Button
-              size="sm"
-              layout="icon-only"
-              variant="tertiary"
+            <button
               onClick={onAdd}
               aria-label="투두 추가"
-              className="h-10 w-10 rounded-[24px] bg-category-control p-0 text-category-control-icon"
-              icon={
-                <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
-                  <path d="M8 3.33V12.67M3.33 8H12.67" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
-                </svg>
-              }
-            />
+              className="flex h-10 w-10 items-center justify-center rounded-[24px] bg-[#EBEBEC]"
+            >
+              <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true">
+                <path
+                  d="M8 3.33V12.67M3.33 8H12.67"
+                  stroke="#27272A"
+                  strokeWidth="1.5"
+                  strokeLinecap="round"
+                />
+              </svg>
+            </button>
           </div>
 
           {/* 배경·카드를 포함한 네 페이지를 하나의 가로 track으로 이동 */}
-          <motion.div
+          <div
             className="absolute inset-0 z-0 flex h-full w-full"
-            animate={{ x: `calc(-${currentIndex * 100}% + ${dragX}px)` }}
-            transition={{ duration: isSettling ? 0.18 : 0, ease: 'easeOut' }}
+            style={{
+              transform: `translateX(calc(-${currentIndex * 100}% + ${dragX}px))`,
+              transition: slideTransition,
+            }}
           >
             {TODO_CATEGORY_ORDER.map(panelCategory => {
               const isCurrentPage = panelCategory === category;
@@ -588,7 +622,7 @@ export const CategoryDetailView = ({
                 </div>
               );
             })}
-          </motion.div>
+          </div>
         </motion.div>
       )}
     </AnimatePresence>

--- a/src/feature/todo/todoList/components/CategoryNavigation.tsx
+++ b/src/feature/todo/todoList/components/CategoryNavigation.tsx
@@ -2,8 +2,11 @@
 
 import { KeyboardEvent, useRef } from 'react';
 import { motion, type PanInfo } from 'motion/react';
-import Button from '@/shared/components/input/Button';
-import { TODO_CATEGORY_NAV_META, TODO_CATEGORY_ORDER, type TodoCategory } from '../category';
+import {
+  TODO_CATEGORY_NAV_META,
+  TODO_CATEGORY_ORDER,
+  type TodoCategory,
+} from '../category';
 
 const SWIPE_THRESHOLD = 48;
 
@@ -13,6 +16,7 @@ interface CategoryNavigationProps {
 }
 
 export const CategoryNavigation = ({ value, onValueChange }: CategoryNavigationProps) => {
+  const tabRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const didDrag = useRef(false);
 
   const selectAt = (index: number) => {
@@ -20,7 +24,7 @@ export const CategoryNavigation = ({ value, onValueChange }: CategoryNavigationP
     if (!category) return;
 
     onValueChange(category);
-    document.getElementById(`todo-category-tab-${category.toLowerCase()}`)?.focus();
+    tabRefs.current[index]?.focus();
   };
 
   const handleKeyDown = (event: KeyboardEvent<HTMLButtonElement>, index: number) => {
@@ -60,7 +64,7 @@ export const CategoryNavigation = ({ value, onValueChange }: CategoryNavigationP
     <motion.div
       role="tablist"
       aria-label="투두 카테고리"
-      className="grid h-10 w-[176px] touch-pan-y grid-cols-4 overflow-hidden rounded-[24px] bg-category-panel p-1"
+      className="grid h-10 w-[176px] grid-cols-4 overflow-hidden rounded-[24px] bg-[#171717] p-1"
       drag="x"
       dragConstraints={{ left: 0, right: 0 }}
       dragElastic={0}
@@ -69,40 +73,39 @@ export const CategoryNavigation = ({ value, onValueChange }: CategoryNavigationP
         didDrag.current = true;
       }}
       onDragEnd={handleDragEnd}
+      style={{ touchAction: 'pan-y' }}
     >
       {TODO_CATEGORY_ORDER.map((category, index) => {
         const isSelected = category === value;
         const meta = TODO_CATEGORY_NAV_META[category];
 
         return (
-          <Button
+          <button
             key={category}
-            size="sm"
-            layout="icon-only"
-            variant="tertiary"
+            ref={element => {
+              tabRefs.current[index] = element;
+            }}
             type="button"
             role="tab"
             id={`todo-category-tab-${category.toLowerCase()}`}
             aria-selected={isSelected}
-            aria-controls={`todo-category-panel-${category.toLowerCase()}`}
+            aria-controls="todo-category-panel"
             aria-label={meta.label}
             tabIndex={isSelected ? 0 : -1}
-            className="rounded-[18px] p-0 transition-colors"
+            className="flex items-center justify-center rounded-[18px] transition-colors"
             onClick={() => {
               if (!didDrag.current) onValueChange(category);
             }}
             onKeyDown={event => handleKeyDown(event, index)}
-            icon={
-              <span
-                aria-hidden="true"
-                className={`size-3 rounded-[2px] ${isSelected ? meta.activeClassName : 'bg-category-tab-inactive'}`}
-              />
-            }
-          />
+          >
+            <span
+              aria-hidden="true"
+              className="size-3 rounded-[2px]"
+              style={{ backgroundColor: isSelected ? meta.activeColor : '#404040' }}
+            />
+          </button>
         );
       })}
     </motion.div>
   );
 };
-
-export default CategoryNavigation;

--- a/src/feature/todo/todoList/components/MatrixView.tsx
+++ b/src/feature/todo/todoList/components/MatrixView.tsx
@@ -14,42 +14,27 @@ interface MatrixViewProps {
 }
 
 // Figma 196:1617 — color/lime/900 (#35530E) × opacity 16%
-const CARD_BG = 'bg-fill-brand/15';
+const CARD_BG = 'bg-[#35530E29]';
 
 // Accent colors per Figma 196:1623, 196:1646, etc. (Pretendard SemiBold 12px)
 // Icon assets exported from Figma 196:1554 (IcChar03/04 등 디자인 시스템)
 const CATEGORY_CONFIG = {
-  NOW: { title: '긴급', iconSrc: '/icon/category-now.png', accentClassName: 'text-category-now', bgStyle: CARD_BG },
-  STEADY: {
-    title: '꾸준히',
-    iconSrc: '/icon/category-steady.png',
-    accentClassName: 'text-category-steady',
-    bgStyle: CARD_BG,
-  },
-  SKIP: {
-    title: '넘겨도',
-    iconSrc: '/icon/category-skip.png',
-    accentClassName: 'text-category-skip',
-    bgStyle: CARD_BG,
-  },
-  DELETE: {
-    title: '지워도',
-    iconSrc: '/icon/category-delete.png',
-    accentClassName: 'text-category-delete',
-    bgStyle: CARD_BG,
-  },
+  NOW: { title: '긴급', iconSrc: '/icon/category-now.png', accentColor: '#FF6467', bgStyle: CARD_BG },
+  STEADY: { title: '꾸준히', iconSrc: '/icon/category-steady.png', accentColor: '#FF8904', bgStyle: CARD_BG },
+  SKIP: { title: '넘겨도', iconSrc: '/icon/category-skip.png', accentColor: '#51A2FF', bgStyle: CARD_BG },
+  DELETE: { title: '지워도', iconSrc: '/icon/category-delete.png', accentColor: '#A1A1A1', bgStyle: CARD_BG },
 } as const;
 
 export const MatrixView = ({ groups, onToggle, onDelete, onEdit, onAdd, onCardClick }: MatrixViewProps) => {
   return (
     <div className="mb-5 flex flex-col gap-4">
       <div className="flex flex-col gap-2">
-        <p className="text-[13px] font-medium text-category-section-label">중요</p>
+        <p className="text-[13px] font-medium text-[#F4F4F5]">중요</p>
         <div className="flex h-[295px] shrink-0 flex-row gap-2">
           <CategoryCard
             title={CATEGORY_CONFIG.NOW.title}
             iconSrc={CATEGORY_CONFIG.NOW.iconSrc}
-            accentClassName={CATEGORY_CONFIG.NOW.accentClassName}
+            accentColor={CATEGORY_CONFIG.NOW.accentColor}
             bgStyle={CATEGORY_CONFIG.NOW.bgStyle}
             todos={groups.NOW}
             onToggle={onToggle}
@@ -61,7 +46,7 @@ export const MatrixView = ({ groups, onToggle, onDelete, onEdit, onAdd, onCardCl
           <CategoryCard
             title={CATEGORY_CONFIG.STEADY.title}
             iconSrc={CATEGORY_CONFIG.STEADY.iconSrc}
-            accentClassName={CATEGORY_CONFIG.STEADY.accentClassName}
+            accentColor={CATEGORY_CONFIG.STEADY.accentColor}
             bgStyle={CATEGORY_CONFIG.STEADY.bgStyle}
             todos={groups.STEADY}
             onToggle={onToggle}
@@ -74,12 +59,12 @@ export const MatrixView = ({ groups, onToggle, onDelete, onEdit, onAdd, onCardCl
       </div>
 
       <div className="flex flex-col gap-2">
-        <p className="text-[13px] font-medium text-category-section-label">여유</p>
+        <p className="text-[13px] font-medium text-[#F4F4F5]">여유</p>
         <div className="flex h-[180px] shrink-0 flex-row gap-2">
           <CategoryCard
             title={CATEGORY_CONFIG.SKIP.title}
             iconSrc={CATEGORY_CONFIG.SKIP.iconSrc}
-            accentClassName={CATEGORY_CONFIG.SKIP.accentClassName}
+            accentColor={CATEGORY_CONFIG.SKIP.accentColor}
             bgStyle={CATEGORY_CONFIG.SKIP.bgStyle}
             todos={groups.SKIP}
             onToggle={onToggle}
@@ -91,7 +76,7 @@ export const MatrixView = ({ groups, onToggle, onDelete, onEdit, onAdd, onCardCl
           <CategoryCard
             title={CATEGORY_CONFIG.DELETE.title}
             iconSrc={CATEGORY_CONFIG.DELETE.iconSrc}
-            accentClassName={CATEGORY_CONFIG.DELETE.accentClassName}
+            accentColor={CATEGORY_CONFIG.DELETE.accentColor}
             bgStyle={CATEGORY_CONFIG.DELETE.bgStyle}
             todos={groups.DELETE}
             onToggle={onToggle}

--- a/src/shared/components/layout/Navigation/BottomNavigation.tsx
+++ b/src/shared/components/layout/Navigation/BottomNavigation.tsx
@@ -30,7 +30,7 @@ export const BottomNavigation = () => {
     <nav
       className={`relative w-full shrink-0 bg-transparent px-[25px] pb-[calc(25px+env(safe-area-inset-bottom,0px))] pt-4 flex items-center justify-between ${Z_INDEX.BOTTOM_NAVIGATION}`}
     >
-      <div className="grid w-[236px] max-w-full grid-cols-3 items-center gap-[2px] rounded-[28px] bg-category-panel px-2 py-1 backdrop-blur-[0px]">
+      <div className="grid w-[236px] max-w-full grid-cols-3 items-center gap-[2px] rounded-[28px] bg-[#171717] px-2 py-1 backdrop-blur-[0px]">
         {NAV_ITEMS.map(item => (
           <NavTabButton
             key={item.path}

--- a/src/shared/components/layout/Navigation/NavTabButton.tsx
+++ b/src/shared/components/layout/Navigation/NavTabButton.tsx
@@ -25,7 +25,7 @@ export const NavTabButton = ({ Icon, label, active, onClick }: NavTabButtonProps
     onClick={onClick}
     whileTap={{ scale: 0.94 }}
     className={`relative flex w-full min-w-0 items-center justify-center px-1 py-3 transition-colors duration-200 ${
-      active ? 'text-text-strong' : 'text-category-muted'
+      active ? 'text-[#FCFCFC]' : 'text-[#A1A1A1]'
     }`}
     aria-pressed={active}
   >
@@ -33,7 +33,7 @@ export const NavTabButton = ({ Icon, label, active, onClick }: NavTabButtonProps
       <motion.span
         layoutId="bottom-navigation-active-pill"
         aria-hidden="true"
-        className="absolute inset-y-0 -left-1 -right-1 rounded-3xl bg-category-tab-inactive shadow-sm"
+        className="absolute inset-y-0 -left-1 -right-1 rounded-3xl bg-[#404040] shadow-[0px_2px_8px_rgba(0,0,0,0.06)]"
         transition={{ type: 'spring', stiffness: 420, damping: 34 }}
       />
     )}
@@ -52,7 +52,7 @@ export const NavTabButton = ({ Icon, label, active, onClick }: NavTabButtonProps
           animate={{ width: 'auto', marginLeft: 12, opacity: 1, x: 0 }}
           exit={{ width: 0, marginLeft: 0, opacity: 0, x: -4 }}
           transition={{ duration: 0.2, ease: 'easeOut' }}
-          className="relative overflow-hidden whitespace-nowrap text-[14px] font-medium leading-[1.43] text-text-strong"
+          className="relative overflow-hidden whitespace-nowrap text-[14px] font-medium leading-[1.43] text-[#FCFCFC]"
         >
           {label}
         </motion.span>


### PR DESCRIPTION
## Summary
- 카테고리 디자인 시스템 치환으로 달라진 기존 스타일을 복원했습니다.
- 카드 배경은 예외적으로 기존 색상의 8자리 HEX `#35530E29`를 사용합니다.
- 상세 패널 제목과 카테고리 배지 카피를 최신 요구사항에 맞췄습니다.

## Changes
- 긴급/꾸준히/넘겨도/지워도 카드 배경 복원
- 상세 상단 컨트롤 및 카테고리 네비게이션 버튼 스타일 복원
- 카테고리 카드 내부 추가 버튼 스타일 복원
- 상세 제목: 빨리 끝내기 / 꾸준히하기 / 여유롭게 끝내기 / 천천히 끝내기
- 상세 배지: 긴급 / 꾸준히 / 넘겨도 / 지워도

## Verification
- `npx tsc --noEmit` 통과
- 변경 파일 ESLint 통과
- `git diff --check` 통과